### PR TITLE
Easy setup and bulid for musl

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,16 @@
+[tasks.check-dist]
+command = "cargo"
+args = ["check", "-p", "dragonfly-agent", "--target", "x86_64-unknown-linux-musl"]
+workspace = false
+
+[tasks.build-dist]
+command = "cargo"
+args = ["build", "--release", "-p", "dragonfly-agent", "--target", "x86_64-unknown-linux-musl"]
+workspace = false
+
+[tasks.build-all]
+command = "cargo"
+args = ["build", "${@}"]
+dependencies = [ "build-dist" ]
+workspace = false
+

--- a/README.md
+++ b/README.md
@@ -113,6 +113,40 @@ This enables:
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for more details on deployment patterns.
 
+### Nix development and build environment (WIP)
+ 
+use nix package manager and `cargo-make` to develop and build with distribution in mind.
+
+```
+sudo apt install nix
+nix develop
+# build distribution binaries
+cargo make build-dist
+# build everyithing, + distribution binaries
+cargo make build-all [--release]
+# run cargo check on the distribution build
+cargo make check-dist
+```
+
+> See `Makefile.toml` for `cargo make` commands
+
+using `nix develop` should JustWork^tm for setting up an ephemeral development and build environment, this includes:
+
+- rust, and assosciated tooling such as rustup, toolchains, etc.
+- installation of system libraries such as muslibc
+- installation of static package libraries such as openssl
+- setting of environment variables to use said tools
+
+This process is defined in `flake.nix`. The changes made for this set-up only persist in the shell where `nix develop` was executed
+
+To automate the entry/exit of the dev environment:
+
+- install `direnv`
+- `echo "use flake" > .envrc` (in the root of the dir-tree)
+- `direnv allow`
+
+> The plan is to field-test this approach, and if received well, extend it to more aspects, such as testing, CI/CD, distribution, tooling setup, etc.
+
 ### Development Mode
 
 For local development without installation:

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,20 @@
       with pkgs;
       {
         devShells.default = mkShell {
+          SQLITE3_STATIC = "1";
+          LIBSQLITE3_SYS_USE_PKG_CONFIG = "1";
           buildInputs = [
             rustToolchain
             openssl
             pkg-config
             pkgsStatic.stdenv.cc
             pkgsStatic.openssl
+            pkgsStatic.sqlite
+            pkgsStatic.aws-lc
+            pkgsStatic.libssh2
+            pkgsStatic.zlib
+            nodejs
+            cargo-make
           ];
           
           # For target compilation
@@ -47,6 +55,15 @@
           PKG_CONFIG_ALL_STATIC = "1";
           
           shellHook = ''
+            echo "Setting up Node.js environment..."
+            export PATH="${pkgs.nodejs}/bin:$PATH"
+
+            # Only install Tailwind if node_modules doesn't exist
+            if [ ! -d "node_modules" ]; then
+              echo "Installing Tailwind CSS..."
+              npm install -D tailwindcss postcss autoprefixer
+              npx tailwindcss init
+            fi
             echo "Rust musl target added"
             echo "Target linker: $CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER"
           '';


### PR DESCRIPTION
Using nix to setup an ephemeral dev-shell, `cargo make build-dist` should Just Work^tm to provide musl libc compiled binaries: all neccisary dependencies, environment variables, etc. will be added just for the shell that is within the root of this project.

With this approach, it should be relatively straight forward to provide for any platform.