### PR TITLE
Spark/Mage agents: WebSocket push channel for prompt reimage pickup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,8 @@ Flight and Swarm are equally capable for datacenter management. Swarm adds multi
 - Handle errors gracefully with proper error messages
 
 ## Issue Tracking
-- **ALL internal tickets go in Plane** — project **FLY** (Dragonfly)
-- Project ID: `e8dc5d17-e534-4327-87c7-86475dee02b2`
-- Use `mcp__plane__plane_entity` to create/list/update issues
-- Do NOT use GitHub Issues for internal tracking
+- Internal tracking uses **GitHub Issues** on [riffcc/dragonfly](https://github.com/riffcc/dragonfly)
+- Reference issues from commits and PRs with `Refs #NN` / `Closes #NN`
 
 ## Development Workflow
 1. **Understand Requirements** - Read README.md and existing code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
  "sha1 0.10.6",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -1660,7 +1660,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1803,6 +1803,7 @@ dependencies = [
  "dragonfly-common",
  "dragonfly-crd",
  "dragonfly-workflow",
+ "futures-util",
  "ratatui",
  "reqwest 0.12.28",
  "scopeguard",
@@ -1811,6 +1812,7 @@ dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.27.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1981,6 +1983,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.27.0",
  "tokio-util",
  "tower 0.4.13",
  "tower-cookies",
@@ -2157,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3178,7 +3181,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4526,7 +4529,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5462,7 +5465,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5499,9 +5502,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6260,7 +6263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7373,7 +7376,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7706,6 +7709,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.27.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -7713,7 +7732,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -8010,6 +8029,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"
@@ -8544,7 +8582,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ More features:
 - 🔍 Search - find any machine by name, tag, or ID.
 - ⚡ Near-instant reimage pickup — agents receive intents over a WebSocket push channel the moment they're set, instead of polling.
 
-## ⚡ Agent push channel (optional)
+## ⚡ Agent push channel
 
-By default the Mage agent polls the server every 30s to pick up reimage and
-OS-assign intents. For near-instant pickup, enable the WebSocket push channel:
-the agent holds a persistent connection and the server pushes intents the
-moment they're set, with no polling in steady state.
+The Mage agent holds a persistent WebSocket to the server and receives reimage
+and OS-assign intents the moment they're set — near-instant pickup with no
+polling in steady state (it previously polled every 30s). It's **on by
+default**: iPXE emits `dragonfly.url` as `ws://` (or `wss://`), so every Mage
+netboot uses the channel automatically.
 
-Enable it with one variable on the **server**, which makes every Mage netboot
-opt in automatically (iPXE emits `dragonfly.url` as `ws://` instead of `http://`):
+To opt out and fall back to the 30s HTTP poll, set one variable on the **server**:
 
-    DRAGONFLY_AGENT_WS=1   # http://server -> ws://server (https:// -> wss://)
+    DRAGONFLY_DISABLE_AGENT_WS=1
 
 Spark (the no_std bare-metal agent) can't hold a WebSocket, so a machine parked
 at Spark's "No OS" menu instead re-checks-in on a short loop and notices a

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ More features:
 - 🩻 Introspection - view details of your machines,
   including hardware, OS, and network configuration.
 - 🔍 Search - find any machine by name, tag, or ID.
+- ⚡ Near-instant reimage pickup — agents receive intents over a WebSocket push channel the moment they're set, instead of polling.
+
+## ⚡ Agent push channel (optional)
+
+By default the Mage agent polls the server every 30s to pick up reimage and
+OS-assign intents. For near-instant pickup, enable the WebSocket push channel:
+the agent holds a persistent connection and the server pushes intents the
+moment they're set, with no polling in steady state.
+
+Enable it with one variable on the **server**, which makes every Mage netboot
+opt in automatically (iPXE emits `dragonfly.url` as `ws://` instead of `http://`):
+
+    DRAGONFLY_AGENT_WS=1   # http://server -> ws://server (https:// -> wss://)
+
+Spark (the no_std bare-metal agent) can't hold a WebSocket, so a machine parked
+at Spark's "No OS" menu instead re-checks-in on a short loop and notices a
+reimage without a manual reboot. That interval is a multiboot cmdline parameter,
+default 5s:
+
+    idle_check_secs=5
 
 ## 🛣️ Roadmap
 

--- a/crates/dragonfly-agent/Cargo.toml
+++ b/crates/dragonfly-agent/Cargo.toml
@@ -21,6 +21,10 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 # Use rustls for TLS to avoid OpenSSL dependency (needed for musl builds)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# WebSocket client for the push channel (replaces the 30s checkin poll).
+# rustls-tls-webpki-roots enables wss://; ws:// works without TLS.
+tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 clap = { version = "4.5", features = ["derive"] }
 
 # OS information gathering

--- a/crates/dragonfly-agent/examples/events_probe.rs
+++ b/crates/dragonfly-agent/examples/events_probe.rs
@@ -1,0 +1,73 @@
+//! Reusable verifier for the `/api/events/ws` stream (orchestrator side).
+//!
+//! Connects, reads the `stream_ready` hello (which proves it's subscribed), then
+//! triggers a checkin — which emits `machine_updated` on the bus — and confirms
+//! the event is forwarded live over the WebSocket. Cleans up the throwaway
+//! machine it registers. A reference for event-driven consumers (e.g. Jetpack).
+//!
+//! Usage: events_probe [WS_BASE_URL]    # default ws://localhost:3000
+
+use std::time::Duration;
+
+use anyhow::Context;
+use futures_util::StreamExt;
+use tokio::time::timeout;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+const MAC: &str = "00:11:22:33:44:bb";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let base = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "ws://localhost:3000".to_string());
+    let http = base.replacen("ws://", "http://", 1).replacen("wss://", "https://", 1);
+
+    let url = format!("{base}/api/events/ws");
+    println!("connecting to {url}");
+    let (mut ws, _) = connect_async(url.as_str()).await?;
+    let hello = ws.next().await.unwrap().unwrap();
+    println!("hello <- {hello}"); // {"type":"stream_ready"}
+
+    // Subscribed now (hello is sent after subscribe): trigger a checkin, which
+    // emits machine_updated on the bus.
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{http}/api/agent/checkin"))
+        .json(&serde_json::json!({ "mac": MAC, "all_macs": [MAC], "existing_os": null }))
+        .send()
+        .await?;
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await?)?;
+    let machine_id = body["machine_id"].as_str().unwrap_or("").to_string();
+    println!("checkin -> machine_id={machine_id}");
+
+    // The events WS must forward the machine_updated event.
+    let mut saw = false;
+    for _ in 0..10 {
+        let msg = match timeout(Duration::from_secs(3), ws.next()).await {
+            Ok(Some(Ok(m))) => m,
+            _ => break,
+        };
+        if let Message::Text(t) = &msg {
+            println!("event <- {t}");
+            if t.contains("machine_updated") {
+                saw = true;
+                break;
+            }
+        }
+    }
+
+    // Clean up the throwaway machine.
+    let _ = client
+        .post(format!("{http}/api/agent/remove"))
+        .json(&serde_json::json!({ "machine_id": machine_id, "mac": MAC }))
+        .send()
+        .await;
+
+    if saw {
+        println!("PASS: /api/events/ws forwarded machine_updated live");
+        Ok(())
+    } else {
+        anyhow::bail!("did not receive machine_updated on the events WS")
+    }
+}

--- a/crates/dragonfly-agent/examples/ws_probe.rs
+++ b/crates/dragonfly-agent/examples/ws_probe.rs
@@ -1,0 +1,93 @@
+//! Reusable debug client for the agent WebSocket push channel.
+//!
+//! Connects to a Dragonfly `/api/agent/ws`, sends a `HardwareCheckIn`, prints
+//! the initial response, then triggers a reimage via `/api/agent/request-install`
+//! (MAC-authed, no login) and prints the pushed response — proving the push path
+//! against a real server. It never executes a workflow; it only observes.
+//!
+//! Usage:
+//!     ws_probe [WS_BASE_URL]            # default ws://localhost:3000
+//!
+//! Env:
+//!     WS_PROBE_MAC        MAC address to register as (default 00:11:22:33:44:aa)
+//!     WS_PROBE_TEMPLATE   OS template to request-install (default debian-12)
+//!
+//! Example:
+//!     WS_PROBE_TEMPLATE=debian-13 cargo run --release --example ws_probe -- ws://10.7.1.100:3000
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::time::timeout;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let base = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "ws://localhost:3000".to_string());
+    let mac = env_or("WS_PROBE_MAC", "00:11:22:33:44:aa");
+    let template = env_or("WS_PROBE_TEMPLATE", "debian-12");
+    let http_base = base.replacen("ws://", "http://", 1).replacen("wss://", "https://", 1);
+
+    let url = format!("{base}/api/agent/ws");
+    println!("connecting to {url} (mac={mac}, template={template})");
+    let (mut ws, _) = connect_async(url.as_str()).await?;
+    println!("connected");
+
+    let checkin = serde_json::json!({ "mac": mac, "all_macs": [mac], "existing_os": null });
+    ws.send(Message::Text(checkin.to_string().into())).await?;
+    println!("sent checkin");
+
+    let first = timeout(Duration::from_secs(5), ws.next())
+        .await
+        .expect("timed out waiting for initial response")
+        .unwrap()
+        .unwrap();
+    let first_str = match first {
+        Message::Text(t) => t.to_string(),
+        other => panic!("expected text, got {other:?}"),
+    };
+    let initial: serde_json::Value = serde_json::from_str(&first_str).unwrap();
+    let action = initial["action"].as_str().unwrap_or("?");
+    let machine_id = initial["machine_id"].as_str().unwrap_or("").to_string();
+    println!("initial  <- action={action} machine_id={machine_id}");
+    assert_eq!(action, "wait", "fresh no-OS machine should get wait");
+
+    // Trigger a reimage via the MAC-authed agent endpoint (emits machine_updated).
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{http_base}/api/agent/request-install"))
+        .json(&serde_json::json!({
+            "machine_id": machine_id,
+            "mac": mac,
+            "template_name": template,
+        }))
+        .send()
+        .await?;
+    println!("request-install ({template}) -> HTTP {}", resp.status());
+
+    let pushed = timeout(Duration::from_secs(5), ws.next())
+        .await
+        .expect("timed out waiting for push")
+        .unwrap()
+        .unwrap();
+    let pushed_str = match pushed {
+        Message::Text(t) => t.to_string(),
+        other => panic!("expected text push, got {other:?}"),
+    };
+    let pushed: serde_json::Value = serde_json::from_str(&pushed_str).unwrap();
+    println!(
+        "pushed   <- action={} workflow_id={}",
+        pushed["action"].as_str().unwrap_or("?"),
+        pushed["workflow_id"]
+    );
+    assert_eq!(pushed["action"].as_str(), Some("execute"));
+    println!("PASS: server pushed execute within the window");
+
+    Ok(())
+}

--- a/crates/dragonfly-agent/src/main.rs
+++ b/crates/dragonfly-agent/src/main.rs
@@ -2,6 +2,7 @@ mod boot_menu;
 mod kexec;
 mod probe;
 mod workflow;
+mod ws;
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -428,6 +429,11 @@ async fn main() -> Result<()> {
         .or_else(|| env::var("DRAGONFLY_API_URL").ok())
         .unwrap_or_else(|| "http://localhost:3000".to_string());
 
+    // A ws:// / wss:// server URL opts the agent into the WebSocket push channel
+    // (near-instant reimage/assign pickup) instead of the 30s HTTP poll. All HTTP
+    // API calls still go to the equivalent http(s):// base.
+    let (api_url, ws_url) = split_server_url(&api_url);
+
     // --- Get required system info FIRST ---
     // Get MAC address and IP address (using improved logic)
     let mac_address = get_mac_address().context("Failed to get MAC address")?;
@@ -567,8 +573,26 @@ async fn main() -> Result<()> {
         Duration::from_secs(args.checkin_interval),
         args.action.clone(),
         kernel_params.mode.as_deref(),
+        ws_url.as_deref(),
     )
     .await
+}
+
+/// Split a configured server URL into its HTTP base and, if it is a WebSocket
+/// scheme, its WebSocket base.
+///
+/// A `ws://`/`wss://` URL opts the agent into the push channel: the HTTP base
+/// (scheme swapped to `http`/`https`) is used for all normal API calls, while
+/// the WebSocket base drives `ws::run_ws_provisioning_loop`. Any other URL
+/// yields no WebSocket base, so the agent keeps using the HTTP poll unchanged.
+fn split_server_url(url: &str) -> (String, Option<String>) {
+    if let Some(rest) = url.strip_prefix("ws://") {
+        (format!("http://{rest}"), Some(format!("ws://{rest}")))
+    } else if let Some(rest) = url.strip_prefix("wss://") {
+        (format!("https://{rest}"), Some(format!("wss://{rest}")))
+    } else {
+        (url.to_string(), None)
+    }
 }
 
 /// Build a Hardware CRD from detected system information
@@ -648,6 +672,7 @@ async fn run_native_provisioning_loop(
     checkin_interval: Duration,
     action_filter: Option<Vec<usize>>,
     boot_mode: Option<&str>,
+    ws_url: Option<&str>,
 ) -> Result<()> {
     let is_imaging = boot_mode == Some("imaging");
     info!("Starting native provisioning (mode={:?})", boot_mode);
@@ -838,6 +863,23 @@ async fn run_native_provisioning_loop(
     // If we get here after LocalBoot/Execute, the action didn't terminate
     // Enter the main loop for ongoing check-ins (only if action was Wait)
     if initial_response.action == AgentAction::Wait {
+        if let Some(ws_base) = ws_url {
+            // WebSocket push channel: a persistent connection replaces the poll,
+            // so a reimage or OS assignment is picked up near-instantly.
+            return ws::run_ws_provisioning_loop(
+                client,
+                ws_base,
+                server_url,
+                mac,
+                effective_hostname,
+                ip_address,
+                &existing_os,
+                &hardware,
+                agent_hw_info,
+                &action_filter,
+            )
+            .await;
+        }
         loop {
             tokio::time::sleep(checkin_interval).await;
 

--- a/crates/dragonfly-agent/src/main.rs
+++ b/crates/dragonfly-agent/src/main.rs
@@ -1410,3 +1410,34 @@ fn get_ip_from_default_route_interface() -> Result<Option<String>> {
 
     Ok(None) // No default route found or couldn't parse it
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_server_url_converts_ws_to_http_base() {
+        // ws:// opts into the push channel; HTTP calls (checkin, workflow fetch)
+        // go to the scheme-swapped base so reqwest never sees a ws:// URL.
+        let (http, ws) = split_server_url("ws://10.7.1.100:3000");
+        assert_eq!(http, "http://10.7.1.100:3000");
+        assert_eq!(ws.as_deref(), Some("ws://10.7.1.100:3000"));
+
+        let (https, wss) = split_server_url("wss://dragonfly.example");
+        assert_eq!(https, "https://dragonfly.example");
+        assert_eq!(wss.as_deref(), Some("wss://dragonfly.example"));
+    }
+
+    #[test]
+    fn split_server_url_passes_http_through_unchanged() {
+        // A non-WS URL leaves the base unchanged and yields no ws base, so the
+        // agent keeps using the HTTP poll.
+        let (http, ws) = split_server_url("http://10.7.1.100:3000");
+        assert_eq!(http, "http://10.7.1.100:3000");
+        assert!(ws.is_none());
+
+        let (https, wss) = split_server_url("https://dragonfly.example");
+        assert_eq!(https, "https://dragonfly.example");
+        assert!(wss.is_none());
+    }
+}

--- a/crates/dragonfly-agent/src/workflow.rs
+++ b/crates/dragonfly-agent/src/workflow.rs
@@ -355,18 +355,17 @@ pub struct AgentHardwareInfo {
     pub nameservers: Vec<String>,
 }
 
-/// Check in with the server using native provisioning endpoint
-pub async fn checkin_native(
-    client: &Client,
-    server_url: &str,
+/// Build the `HardwareCheckIn` JSON payload sent to the server on checkin.
+///
+/// Shared by the HTTP checkin path (`checkin_native`) and the WebSocket push
+/// channel (`ws::run_ws_provisioning_loop`), so both send an identical payload.
+pub fn build_checkin_payload(
     mac: &str,
     hostname: Option<&str>,
     ip_address: Option<&str>,
     existing_os: Option<&DetectedOs>,
     hardware: Option<&AgentHardwareInfo>,
-) -> Result<CheckInResponse> {
-    let url = format!("{}/api/agent/checkin", server_url);
-
+) -> serde_json::Value {
     let mut payload = serde_json::json!({
         "mac": mac,
         "hostname": hostname,
@@ -407,6 +406,21 @@ pub async fn checkin_native(
         }
     }
 
+    payload
+}
+
+/// Check in with the server using native provisioning endpoint
+pub async fn checkin_native(
+    client: &Client,
+    server_url: &str,
+    mac: &str,
+    hostname: Option<&str>,
+    ip_address: Option<&str>,
+    existing_os: Option<&DetectedOs>,
+    hardware: Option<&AgentHardwareInfo>,
+) -> Result<CheckInResponse> {
+    let url = format!("{}/api/agent/checkin", server_url);
+    let payload = build_checkin_payload(mac, hostname, ip_address, existing_os, hardware);
     let response = client.post(&url).json(&payload).send().await?;
 
     if !response.status().is_success() {

--- a/crates/dragonfly-agent/src/ws.rs
+++ b/crates/dragonfly-agent/src/ws.rs
@@ -1,0 +1,192 @@
+//! WebSocket push channel — agent side.
+//!
+//! When the server URL is `ws://`/`wss://`, Mage replaces its 30s checkin poll
+//! with this persistent connection. The agent sends a `HardwareCheckIn` as the
+//! first message, then waits for the server to push `CheckInResponse`
+//! instructions — so a reimage or OS assignment is picked up near-instantly
+//! instead of after the next poll. Steady state is one open socket with nothing
+//! sent on a timer; exponential backoff with small jitter applies only to
+//! reconnection after a drop.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use dragonfly_crd::Hardware;
+use futures_util::{SinkExt, StreamExt};
+use reqwest::Client;
+use tokio::time::sleep;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{info, warn};
+
+use crate::probe::DetectedOs;
+use crate::workflow::{AgentAction, AgentHardwareInfo, CheckInResponse, build_checkin_payload};
+
+/// Minimum and maximum reconnect backoff.
+const BACKOFF_MIN: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Run the WebSocket provisioning loop: connect, drive, reconnect on drop.
+///
+/// Returns once the server has directed a terminal action (Execute/Reboot/
+/// LocalBoot) that `handle_agent_action` has carried out.
+///
+/// `ws_base_url` is the WebSocket base (e.g. `ws://host:3000`); `http_base_url`
+/// is the HTTP base used to fetch the workflow when an `Execute` arrives.
+pub async fn run_ws_provisioning_loop(
+    client: &Client,
+    ws_base_url: &str,
+    http_base_url: &str,
+    mac: &str,
+    hostname: Option<&str>,
+    ip_address: Option<&str>,
+    existing_os: &Option<DetectedOs>,
+    hardware: &Hardware,
+    agent_hw_info: &AgentHardwareInfo,
+    action_filter: &Option<Vec<usize>>,
+) -> Result<()> {
+    let endpoint = format!("{}/api/agent/ws", ws_base_url);
+    info!(endpoint = %endpoint, "Starting WebSocket provisioning loop");
+
+    let mut backoff = BACKOFF_MIN;
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        let outcome = drive_connection(
+            &endpoint,
+            client,
+            http_base_url,
+            mac,
+            hostname,
+            ip_address,
+            existing_os,
+            hardware,
+            agent_hw_info,
+            action_filter,
+        )
+        .await;
+
+        match outcome {
+            Ok(true) => return Ok(()), // terminal action handled
+            Ok(false) => {
+                // Clean disconnect — reconnect promptly.
+                backoff = BACKOFF_MIN;
+            }
+            Err(e) => {
+                warn!(error = %e, attempt, "WebSocket connection lost, will reconnect");
+            }
+        }
+
+        // Reconnect backoff + ±3ms jitter. Steady state never reaches here: the
+        // socket stays open and the agent sends nothing on a timer.
+        sleep(backoff_with_jitter(backoff)).await;
+        backoff = (backoff * 2).min(BACKOFF_MAX);
+    }
+}
+
+/// Drive a single connection. Returns `Ok(true)` when a terminal action was
+/// handled, `Ok(false)` on a clean disconnect, `Err` on a connection error.
+async fn drive_connection(
+    endpoint: &str,
+    client: &Client,
+    http_base_url: &str,
+    mac: &str,
+    hostname: Option<&str>,
+    ip_address: Option<&str>,
+    existing_os: &Option<DetectedOs>,
+    hardware: &Hardware,
+    agent_hw_info: &AgentHardwareInfo,
+    action_filter: &Option<Vec<usize>>,
+) -> Result<bool> {
+    let (ws_stream, _response) = connect_async(endpoint)
+        .await
+        .context("WebSocket connect failed")?;
+    let (mut write, mut read) = ws_stream.split();
+    info!("WebSocket connected");
+
+    // First message identifies this machine — identical payload to an HTTP checkin.
+    let payload = build_checkin_payload(
+        mac,
+        hostname,
+        ip_address,
+        existing_os.as_ref(),
+        Some(agent_hw_info),
+    );
+    let json = serde_json::to_string(&payload).context("serialize checkin payload")?;
+    write
+        .send(Message::Text(json.into()))
+        .await
+        .context("send checkin over WebSocket")?;
+
+    while let Some(msg) = read.next().await {
+        let msg = msg.context("WebSocket receive")?;
+        match msg {
+            Message::Text(text) => {
+                let resp: CheckInResponse = match serde_json::from_str(text.as_str()) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!(error = %e, "ignoring malformed WebSocket message");
+                        continue;
+                    }
+                };
+                info!(action = ?resp.action, "WebSocket checkin response");
+                crate::handle_agent_action(
+                    &resp,
+                    existing_os,
+                    client,
+                    http_base_url,
+                    hardware,
+                    action_filter,
+                )
+                .await?;
+                if resp.action != AgentAction::Wait {
+                    // Execute/Reboot/LocalBoot carried out (the process typically
+                    // reboots/exits as part of handling it).
+                    return Ok(true);
+                }
+            }
+            Message::Close(_) => return Ok(false),
+            // Ping/Pong are answered automatically by tungstenite; Binary is ignored.
+            _ => {}
+        }
+    }
+
+    // Stream ended without an explicit close frame.
+    Ok(false)
+}
+
+/// Add ±3ms jitter to a backoff duration, derived from the clock so we avoid
+/// pulling in a random-number dependency just to de-sync reconnects.
+fn backoff_with_jitter(backoff: Duration) -> Duration {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    // subsec_nanos % 7 -> [0, 6]; shift to [-3, +3] ms.
+    let jitter_ms = (nanos % 7) as i64 - 3;
+    let total_ms = (backoff.as_millis() as i64 + jitter_ms).max(0) as u64;
+    Duration::from_millis(total_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jitter_stays_within_plus_minus_3ms_of_backoff() {
+        for _ in 0..1000 {
+            let jittered = backoff_with_jitter(Duration::from_secs(5));
+            let delta = jittered.as_millis() as i64 - 5_000;
+            assert!(
+                (-3..=3).contains(&delta),
+                "jittered backoff {jittered:?} deviates {delta}ms from 5s"
+            );
+        }
+    }
+
+    #[test]
+    fn jitter_never_goes_negative_for_tiny_backoff() {
+        // 0ms backoff + up to -3ms jitter must clamp to 0, not underflow.
+        let jittered = backoff_with_jitter(Duration::from_millis(0));
+        assert!(jittered.as_millis() <= 3);
+    }
+}

--- a/crates/dragonfly-ipxe/src/script.rs
+++ b/crates/dragonfly-ipxe/src/script.rs
@@ -39,6 +39,12 @@ pub struct IpxeConfig {
     /// Base URL for fetching resources (e.g., http://192.168.1.1:8080)
     pub base_url: String,
 
+    /// Optional agent push URL emitted as `dragonfly.url` in the iPXE kernel
+    /// cmdline (e.g. `ws://host:3000`). When set, Mage boots opt into the
+    /// WebSocket push channel instead of HTTP polling. Asset downloads still
+    /// use `base_url`. When None, `dragonfly.url` falls back to `base_url`.
+    pub agent_url: Option<String>,
+
     /// Spark ELF URL (multiboot2 binary for initial boot)
     pub spark_url: Option<String>,
 
@@ -68,6 +74,7 @@ impl Default for IpxeConfig {
     fn default() -> Self {
         Self {
             base_url: String::new(),
+            agent_url: None,
             spark_url: None,
             kernel_params: Vec::new(),
             console: None,
@@ -516,7 +523,10 @@ boot
         }
 
         // Dragonfly parameters
-        params.push(format!("dragonfly.url={}", self.config.base_url));
+        params.push(format!(
+            "dragonfly.url={}",
+            self.config.agent_url.as_deref().unwrap_or(&self.config.base_url)
+        ));
         params.push(format!("dragonfly.mode={}", mode));
         params.push("dragonfly.mac=${mac}".to_string());
 
@@ -560,7 +570,10 @@ boot
         }
 
         // Dragonfly parameters
-        params.push(format!("dragonfly.url={}", self.config.base_url));
+        params.push(format!(
+            "dragonfly.url={}",
+            self.config.agent_url.as_deref().unwrap_or(&self.config.base_url)
+        ));
         params.push(format!("dragonfly.mode={}", mode));
         params.push("dragonfly.mac=${mac}".to_string());
 
@@ -787,6 +800,34 @@ mod tests {
         // Should NOT have Alpine-specific params
         assert!(!params.contains("alpine_repo"));
         assert!(!params.contains("modules=loop"));
+    }
+
+    #[test]
+    fn test_agent_url_emitted_when_set() {
+        // When agent_url is set, iPXE emits it as dragonfly.url so Mage opts
+        // into the WebSocket push channel (ws:// instead of http://).
+        let mut config = test_config();
+        config.agent_url = Some("ws://10.0.0.1:3000".to_string());
+        let params = IpxeScriptGenerator::new(config).debian_kernel_params(None, "imaging");
+        assert!(
+            params.contains("dragonfly.url=ws://10.0.0.1:3000"),
+            "agent_url must be emitted as dragonfly.url: {params}"
+        );
+    }
+
+    #[test]
+    fn test_agent_url_falls_back_to_base_url() {
+        // Without agent_url, dragonfly.url falls back to the http base_url so
+        // the agent keeps polling (no behavior change when push is disabled).
+        let params = IpxeScriptGenerator::new(test_config()).debian_kernel_params(None, "imaging");
+        assert!(
+            params.contains("dragonfly.url=http://"),
+            "fallback must be the http base_url: {params}"
+        );
+        assert!(
+            !params.contains("dragonfly.url=ws://"),
+            "push must be off by default: {params}"
+        );
     }
 
     #[test]

--- a/crates/dragonfly-server/Cargo.toml
+++ b/crates/dragonfly-server/Cargo.toml
@@ -155,3 +155,5 @@ minijinja-embed = "2.3.0"
 [dev-dependencies]
 tempfile = "3.8"
 serial_test = "3.0"
+# WebSocket client for agent push integration tests.
+tokio-tungstenite = { version = "0.27" }

--- a/crates/dragonfly-server/src/agent_ws.rs
+++ b/crates/dragonfly-server/src/agent_ws.rs
@@ -1,0 +1,278 @@
+//! WebSocket push channel for agents.
+//!
+//! A long-lived alternative to Mage's 30s checkin poll. The agent opens
+//! `GET /api/agent/ws`, sends a `HardwareCheckIn` as the first message, and the
+//! server replies with a `CheckInResponse`. The socket then stays open: whenever
+//! the machine's intent changes (reimage requested, OS assigned, workflow
+//! created), the server pushes a fresh `CheckInResponse` so the agent acts
+//! near-instantly instead of waiting for the next poll.
+//!
+//! Intent is recomputed via `ProvisioningService::current_intent` on each
+//! `machine_updated:{id}` notification (pull-on-notification, not event
+//! sourcing), so steady state is one open socket with no periodic polling.
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use bytes::Bytes;
+use futures::stream::{SplitSink, SplitStream};
+use futures::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio::sync::broadcast;
+use tokio::time::{interval, timeout};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::provisioning::{AgentAction, CheckInResponse, HardwareCheckIn};
+use crate::AppState;
+
+/// Time to wait for the agent's first `HardwareCheckIn` message before giving up.
+const FIRST_MESSAGE_TIMEOUT: Duration = Duration::from_secs(10);
+/// WebSocket ping interval for liveness detection.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// HTTP handler that upgrades an agent connection to a WebSocket.
+///
+/// Auth-less, matching `/api/agent/checkin`: agents have no tokens, and identity
+/// is established MAC-bound from the first message via `handle_checkin`. A WS
+/// connection is longer-lived than a POST, but the threat model is unchanged —
+/// an attacker who can reach the server can already spoof checkins today.
+pub async fn agent_ws_handler(
+    State(state): State<AppState>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    if state.provisioning.is_none() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "Provisioning service not available"})),
+        )
+            .into_response();
+    }
+    ws.on_upgrade(move |socket| run_agent_ws(socket, state))
+}
+
+/// Drive a single agent WebSocket connection for its lifetime.
+async fn run_agent_ws(socket: WebSocket, state: AppState) {
+    let provisioning = match state.provisioning.clone() {
+        Some(p) => p,
+        None => return,
+    };
+    let (mut sender, mut receiver) = socket.split();
+
+    // 1. First message must be a HardwareCheckIn.
+    let checkin = match read_first_checkin(&mut receiver).await {
+        Some(c) => c,
+        None => {
+            let _ = sender.send(Message::Close(None)).await;
+            return;
+        }
+    };
+
+    // 2. Initial checkin + response. handle_checkin does not emit (the HTTP
+    //    handler does), so emit here to refresh the UI.
+    let response = match provisioning.handle_checkin(&checkin).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, mac = %checkin.mac, "agent ws checkin failed");
+            let _ = sender.send(Message::Close(None)).await;
+            return;
+        }
+    };
+    info!(
+        machine_id = %response.machine_id,
+        action = ?response.action,
+        "agent ws connected"
+    );
+    let machine_id: Uuid = match response.machine_id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            let _ = sender.send(Message::Close(None)).await;
+            return;
+        }
+    };
+    let _ = state
+        .event_manager
+        .send(format!("machine_updated:{}", response.machine_id));
+    if send_response(&mut sender, &response).await.is_err() {
+        return;
+    }
+    let mut last_pushed: Option<(AgentAction, Option<String>)> =
+        Some((response.action.clone(), response.workflow_id.clone()));
+
+    // 3. Event loop over inbound messages, server-side notifications, and pings.
+    //    Single task => `last_pushed` has one owner and sends are not concurrent.
+    let mut event_rx = state.event_manager.subscribe();
+    let mut ping = interval(PING_INTERVAL);
+    ping.tick().await; // discard the immediate first tick
+
+    loop {
+        tokio::select! {
+            msg = receiver.next() => match msg {
+                Some(Ok(Message::Text(text))) => {
+                    // Inbound text is an optional re-checkin (heartbeat refresh).
+                    if let Ok(checkin) = serde_json::from_str::<HardwareCheckIn>(&text) {
+                        if let Ok(resp) = provisioning.handle_checkin(&checkin).await {
+                            let _ = state.event_manager.send(
+                                format!("machine_updated:{}", resp.machine_id));
+                            if should_push(last_pushed.as_ref(), &resp) {
+                                if send_response(&mut sender, &resp).await.is_err() {
+                                    break;
+                                }
+                                last_pushed =
+                                    Some((resp.action.clone(), resp.workflow_id.clone()));
+                            }
+                        }
+                    }
+                }
+                Some(Ok(Message::Ping(p))) => {
+                    let _ = sender.send(Message::Pong(p)).await;
+                }
+                Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
+                Some(Ok(_)) => {} // Binary, Pong, etc. — ignore
+            },
+            evt = event_rx.recv() => match evt {
+                Ok(event) if event_concerns_machine(&event, machine_id) => {
+                    match provisioning.current_intent(machine_id).await {
+                        Ok(Some(intent)) => {
+                            if should_push(last_pushed.as_ref(), &intent) {
+                                if send_response(&mut sender, &intent).await.is_err() {
+                                    break;
+                                }
+                                last_pushed =
+                                    Some((intent.action.clone(), intent.workflow_id.clone()));
+                            }
+                        }
+                        Ok(None) => {
+                            // Machine vanished — close the socket.
+                            let _ = sender.send(Message::Close(None)).await;
+                            break;
+                        }
+                        Err(e) => warn!(error = %e, "current_intent failed in ws watcher"),
+                    }
+                }
+                Ok(_) => {} // event for another machine or type
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    // We may have missed the triggering event; recompute unconditionally.
+                    warn!(lag = n, "ws event watcher lagged, recomputing intent");
+                    if let Ok(Some(intent)) = provisioning.current_intent(machine_id).await {
+                        if should_push(last_pushed.as_ref(), &intent) {
+                            if send_response(&mut sender, &intent).await.is_err() {
+                                break;
+                            }
+                            last_pushed =
+                                Some((intent.action.clone(), intent.workflow_id.clone()));
+                        }
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            },
+            _ = ping.tick() => {
+                if sender.send(Message::Ping(Bytes::new())).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+    let _ = sender.send(Message::Close(None)).await;
+}
+
+/// Read and parse the first message as a `HardwareCheckIn`, with a timeout.
+async fn read_first_checkin(receiver: &mut SplitStream<WebSocket>) -> Option<HardwareCheckIn> {
+    let msg = timeout(FIRST_MESSAGE_TIMEOUT, receiver.next()).await.ok()??;
+    match msg {
+        Ok(Message::Text(text)) => serde_json::from_str(&text).ok(),
+        _ => None,
+    }
+}
+
+/// Serialize and send a `CheckInResponse` as a text message.
+async fn send_response(
+    sender: &mut SplitSink<WebSocket, Message>,
+    response: &CheckInResponse,
+) -> Result<(), ()> {
+    let json = serde_json::to_string(response).map_err(|_| ())?;
+    sender.send(Message::Text(json.into())).await.map_err(|_| ())
+}
+
+/// Whether a freshly-computed intent should be pushed to the agent.
+///
+/// The push channel only drives `Wait → Execute`; `LocalBoot`/`Reboot` are never
+/// pushed (the agent already acted on its initial response, and the channel
+/// cannot re-probe the disk). Returns true only when the action/workflow differs
+/// from what was last pushed.
+fn should_push(last: Option<&(AgentAction, Option<String>)>, new: &CheckInResponse) -> bool {
+    if matches!(new.action, AgentAction::Reboot | AgentAction::LocalBoot) {
+        return false;
+    }
+    let key = (new.action.clone(), new.workflow_id.clone());
+    Some(&key) != last
+}
+
+/// Whether a server event string pertains to a given machine.
+///
+/// Events are `"{type}:{uuid}"`. We react to `machine_updated`/`machine_deleted`
+/// for our machine only.
+fn event_concerns_machine(event: &str, machine_id: Uuid) -> bool {
+    let Some((kind, id)) = event.split_once(':') else {
+        return false;
+    };
+    let kind_match = matches!(kind, "machine_updated" | "machine_deleted");
+    let id_match = Uuid::parse_str(id.trim()).map_or(false, |parsed| parsed == machine_id);
+    kind_match && id_match
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resp(action: AgentAction, wf: Option<&str>) -> CheckInResponse {
+        CheckInResponse {
+            machine_id: Uuid::now_v7().to_string(),
+            memorable_name: "m".to_string(),
+            is_new: false,
+            action,
+            workflow_id: wf.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn event_concerns_machine_matches_our_machine() {
+        let id = Uuid::now_v7();
+        assert!(event_concerns_machine(&format!("machine_updated:{id}"), id));
+        assert!(event_concerns_machine(&format!("machine_deleted:{id}"), id));
+    }
+
+    #[test]
+    fn event_concerns_machine_ignores_other_machines_and_types() {
+        let id = Uuid::now_v7();
+        let other = Uuid::now_v7();
+        assert!(!event_concerns_machine(&format!("machine_updated:{other}"), id));
+        assert!(!event_concerns_machine(&format!("workflow_progress:{id}"), id));
+        assert!(!event_concerns_machine("templates_ready", id));
+    }
+
+    #[test]
+    fn should_push_only_wait_or_execute_and_only_on_change() {
+        let wait = resp(AgentAction::Wait, None);
+        let exec1 = resp(AgentAction::Execute, Some("wf-1"));
+        let exec2 = resp(AgentAction::Execute, Some("wf-2"));
+        let localboot = resp(AgentAction::LocalBoot, None);
+        let reboot = resp(AgentAction::Reboot, None);
+
+        // Nothing pushed yet: Wait and Execute push; LocalBoot/Reboot never do.
+        assert!(should_push(None, &wait));
+        assert!(should_push(None, &exec1));
+        assert!(!should_push(None, &localboot));
+        assert!(!should_push(None, &reboot));
+
+        // After Execute(wf-1) was pushed, the same doesn't re-push; a different
+        // workflow does, and a return to Wait also does.
+        let last = (AgentAction::Execute, Some("wf-1".to_string()));
+        assert!(!should_push(Some(&last), &exec1));
+        assert!(should_push(Some(&last), &exec2));
+        assert!(should_push(Some(&last), &wait));
+        assert!(!should_push(Some(&last), &localboot));
+    }
+}

--- a/crates/dragonfly-server/src/agent_ws.rs
+++ b/crates/dragonfly-server/src/agent_ws.rs
@@ -275,4 +275,83 @@ mod tests {
         assert!(should_push(Some(&last), &wait));
         assert!(!should_push(Some(&last), &localboot));
     }
+
+    /// End-to-end: boot the real API router on a socket, connect a real
+    /// WebSocket client, and confirm a pushed `Execute` arrives when the
+    /// machine's intent changes — the core of issue #18.
+    #[tokio::test]
+    async fn ws_handler_pushes_execute_when_intent_changes() {
+        use crate::api::api_router;
+        use crate::test_helpers::create_test_app_state_with_provisioning;
+        use futures::{SinkExt, StreamExt};
+        use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+        // Boot the real router (provisioning enabled) on an ephemeral port.
+        // api_router() is mounted under /api, exactly as the real server does it.
+        let state = create_test_app_state_with_provisioning().await;
+        let app = axum::Router::new()
+            .nest("/api", api_router())
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app.into_make_service()).await;
+        });
+
+        // Connect a real WebSocket client and send a HardwareCheckIn.
+        let url = format!("ws://{addr}/api/agent/ws");
+        let (mut ws, _response) = connect_async(url.as_str()).await.unwrap();
+        let checkin = serde_json::json!({
+            "mac": "00:11:22:33:44:99",
+            "all_macs": ["00:11:22:33:44:99"],
+            "existing_os": null,
+        });
+        ws.send(Message::Text(checkin.to_string().into()))
+            .await
+            .unwrap();
+
+        // CheckInResponse is Serialize-only on the server side, so parse the wire
+        // JSON into a tiny local view for assertions.
+        #[derive(serde::Deserialize)]
+        struct WireResponse {
+            machine_id: String,
+            action: String,
+            workflow_id: Option<String>,
+        }
+
+        // Initial response: a fresh no-OS machine with no os_choice -> wait.
+        let first = ws.next().await.unwrap().unwrap();
+        let first_text = match first {
+            Message::Text(t) => t,
+            other => panic!("expected text message, got {other:?}"),
+        };
+        let initial: WireResponse = serde_json::from_str(first_text.as_str()).unwrap();
+        assert_eq!(initial.action, "wait");
+        let machine_id: Uuid = initial.machine_id.parse().unwrap();
+
+        // Simulate exactly what assign_os now does: set os_choice, persist, emit.
+        let mut machine = state.store.get_machine(machine_id).await.unwrap().unwrap();
+        machine.config.os_choice = Some("debian-12".to_string());
+        state.store.put_machine(&machine).await.unwrap();
+        let _ = state
+            .event_manager
+            .send(format!("machine_updated:{machine_id}"));
+
+        // The server must push a fresh execute (workflow created) within seconds.
+        let pushed = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+            .await
+            .expect("timed out waiting for push")
+            .unwrap()
+            .unwrap();
+        let pushed_text = match pushed {
+            Message::Text(t) => t,
+            other => panic!("expected text push, got {other:?}"),
+        };
+        let pushed: WireResponse = serde_json::from_str(pushed_text.as_str()).unwrap();
+        assert_eq!(pushed.action, "execute");
+        assert!(
+            pushed.workflow_id.is_some(),
+            "pushed execute must carry a workflow_id"
+        );
+    }
 }

--- a/crates/dragonfly-server/src/api.rs
+++ b/crates/dragonfly-server/src/api.rs
@@ -261,6 +261,7 @@ pub fn api_router() -> Router<crate::AppState> {
         .route("/tags/{tag_name}/machines", get(api_get_machines_by_tag))
         // --- Agent Routes ---
         .route("/agent/checkin", post(agent_checkin_handler))
+        .route("/agent/ws", get(crate::agent_ws::agent_ws_handler))
         .route(
             "/agent/request-install",
             post(agent_request_install_handler),

--- a/crates/dragonfly-server/src/api.rs
+++ b/crates/dragonfly-server/src/api.rs
@@ -1277,6 +1277,13 @@ async fn assign_os_internal(app_state: &AppState, id: Uuid, os_choice: String) -
     // Save back to store
     match app_state.store.put_machine(&machine).await {
         Ok(()) => {
+            // Notify subscribers (UI + connected agent WebSockets) that this
+            // machine's intent may have changed. Without this, assigning an OS to
+            // an idle machine never triggers a push, so a Mage agent on the
+            // WebSocket path would not pick it up until its next poll.
+            let _ = app_state
+                .event_manager
+                .send(format!("machine_updated:{}", id));
             let html = if os_choice.is_empty() {
                 format!(
                     r###"

--- a/crates/dragonfly-server/src/lib.rs
+++ b/crates/dragonfly-server/src/lib.rs
@@ -139,6 +139,33 @@ pub fn read_base_url_from_config() -> Option<String> {
     None
 }
 
+/// Derive the agent WebSocket push URL to emit in iPXE when push is enabled.
+///
+/// Enabled by `DRAGONFLY_AGENT_WS=1` (or any truthy value). When enabled, the
+/// agent URL is the base URL with its scheme swapped to `ws://` (from `http://`)
+/// or `wss://` (from `https://`), so Mage boots opt into the WebSocket push
+/// channel. Returns None when disabled — iPXE then emits the plain `http://`
+/// base URL and the agent polls as before.
+fn agent_ws_url(base_url: &str) -> Option<String> {
+    let enabled = std::env::var("DRAGONFLY_AGENT_WS")
+        .ok()
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no" && v != "off"
+        })
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    Some(
+        base_url
+            .strip_prefix("https://")
+            .map(|r| format!("wss://{r}"))
+            .or_else(|| base_url.strip_prefix("http://").map(|r| format!("ws://{r}")))
+            .unwrap_or_else(|| base_url.to_string()),
+    )
+}
+
 // Stub function to check installation status (Replace with real check later)
 // Checks environment variable DRAGONFLY_FORCE_INSTALLED=true for testing
 // Also checks for /var/lib/dragonfly and dragonfly StatefulSet status
@@ -1155,10 +1182,16 @@ pub async fn run() -> anyhow::Result<()> {
         // Get boot server URL with auto-detection (env var > SQLite > auto-detect > localhost)
         let boot_server_url = mode::get_base_url(Some(store.as_ref())).await;
         info!("Using boot server URL: {}", boot_server_url);
+        // Optionally expose the agent push channel by emitting dragonfly.url as ws://
+        let agent_url = agent_ws_url(&boot_server_url);
+        if let Some(ref u) = agent_url {
+            info!("Agent WebSocket push enabled, emitting dragonfly.url={}", u);
+        }
 
         // Build iPXE configuration
         let ipxe_config = dragonfly_ipxe::IpxeConfig {
             base_url: boot_server_url,
+            agent_url,
             spark_url: std::env::var("DRAGONFLY_SPARK_URL").ok(),
             mage_kernel_url: std::env::var("DRAGONFLY_MAGE_KERNEL_URL").ok(),
             mage_initramfs_url: std::env::var("DRAGONFLY_MAGE_INITRAMFS_URL").ok(),

--- a/crates/dragonfly-server/src/lib.rs
+++ b/crates/dragonfly-server/src/lib.rs
@@ -41,6 +41,7 @@ use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt};
 mod api;
 pub mod api_token;
 mod auth;
+pub mod agent_ws;
 pub mod cluster;
 pub mod dns_sync;
 pub mod event_manager;

--- a/crates/dragonfly-server/src/lib.rs
+++ b/crates/dragonfly-server/src/lib.rs
@@ -139,31 +139,41 @@ pub fn read_base_url_from_config() -> Option<String> {
     None
 }
 
-/// Derive the agent WebSocket push URL to emit in iPXE when push is enabled.
+/// Derive the agent WebSocket push URL to emit in iPXE.
 ///
-/// Enabled by `DRAGONFLY_AGENT_WS=1` (or any truthy value). When enabled, the
-/// agent URL is the base URL with its scheme swapped to `ws://` (from `http://`)
-/// or `wss://` (from `https://`), so Mage boots opt into the WebSocket push
-/// channel. Returns None when disabled — iPXE then emits the plain `http://`
-/// base URL and the agent polls as before.
+/// Push is **on by default**: the agent URL is the base URL with its scheme
+/// swapped to `ws://` (from `http://`) or `wss://` (from `https://`), so Mage
+/// boots opt into the WebSocket push channel automatically. Opt out by setting
+/// `DRAGONFLY_DISABLE_AGENT_WS=1` (or any truthy value); iPXE then emits the
+/// plain `http://` base URL and the agent polls as before.
 fn agent_ws_url(base_url: &str) -> Option<String> {
-    let enabled = std::env::var("DRAGONFLY_AGENT_WS")
-        .ok()
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            !v.is_empty() && v != "0" && v != "false" && v != "no" && v != "off"
-        })
-        .unwrap_or(false);
-    if !enabled {
+    if agent_ws_disabled(std::env::var("DRAGONFLY_DISABLE_AGENT_WS").ok().as_deref()) {
         return None;
     }
-    Some(
-        base_url
-            .strip_prefix("https://")
-            .map(|r| format!("wss://{r}"))
-            .or_else(|| base_url.strip_prefix("http://").map(|r| format!("ws://{r}")))
-            .unwrap_or_else(|| base_url.to_string()),
-    )
+    Some(swap_to_ws(base_url))
+}
+
+/// Truthiness of the `DRAGONFLY_DISABLE_AGENT_WS` opt-out flag.
+///
+/// `None`/empty/`0`/`false`/`no`/`off` => push stays **on** (the default);
+/// anything else => push disabled. Kept pure so the default is unit-testable.
+fn agent_ws_disabled(env_value: Option<&str>) -> bool {
+    match env_value {
+        Some(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no" && v != "off"
+        }
+        None => false,
+    }
+}
+
+/// Swap an http(s) base URL to the ws(s) equivalent for the agent channel.
+fn swap_to_ws(base_url: &str) -> String {
+    base_url
+        .strip_prefix("https://")
+        .map(|r| format!("wss://{r}"))
+        .or_else(|| base_url.strip_prefix("http://").map(|r| format!("ws://{r}")))
+        .unwrap_or_else(|| base_url.to_string())
 }
 
 // Stub function to check installation status (Replace with real check later)
@@ -1182,10 +1192,16 @@ pub async fn run() -> anyhow::Result<()> {
         // Get boot server URL with auto-detection (env var > SQLite > auto-detect > localhost)
         let boot_server_url = mode::get_base_url(Some(store.as_ref())).await;
         info!("Using boot server URL: {}", boot_server_url);
-        // Optionally expose the agent push channel by emitting dragonfly.url as ws://
+        // Agent push channel: on by default (emits dragonfly.url as ws://).
         let agent_url = agent_ws_url(&boot_server_url);
-        if let Some(ref u) = agent_url {
-            info!("Agent WebSocket push enabled, emitting dragonfly.url={}", u);
+        match agent_url.as_ref() {
+            Some(u) => info!(
+                "Agent WebSocket push enabled (on by default), emitting dragonfly.url={}",
+                u
+            ),
+            None => info!(
+                "Agent WebSocket push disabled via DRAGONFLY_DISABLE_AGENT_WS; agent will poll"
+            ),
         }
 
         // Build iPXE configuration
@@ -1533,3 +1549,36 @@ pub mod test_helpers;
 
 #[cfg(test)]
 pub use test_helpers::create_test_app_state;
+
+#[cfg(test)]
+mod agent_ws_tests {
+    use super::*;
+
+    #[test]
+    fn push_is_on_by_default() {
+        // No opt-out flag (or a falsy one) => push stays ON — the sane default.
+        assert!(!agent_ws_disabled(None));
+        assert!(!agent_ws_disabled(Some("")));
+        assert!(!agent_ws_disabled(Some("0")));
+        assert!(!agent_ws_disabled(Some("false")));
+        assert!(!agent_ws_disabled(Some("no")));
+        assert!(!agent_ws_disabled(Some("off")));
+    }
+
+    #[test]
+    fn push_can_be_disabled() {
+        assert!(agent_ws_disabled(Some("1")));
+        assert!(agent_ws_disabled(Some("true")));
+        assert!(agent_ws_disabled(Some("yes")));
+        assert!(agent_ws_disabled(Some("on")));
+        assert!(agent_ws_disabled(Some("  TRUE  ")));
+    }
+
+    #[test]
+    fn swap_to_ws_scheme() {
+        assert_eq!(swap_to_ws("http://10.7.1.100:3000"), "ws://10.7.1.100:3000");
+        assert_eq!(swap_to_ws("https://dragonfly.example"), "wss://dragonfly.example");
+        // Unknown scheme passes through unchanged (agent then treats it as http).
+        assert_eq!(swap_to_ws("foo://x"), "foo://x");
+    }
+}

--- a/crates/dragonfly-server/src/provisioning.rs
+++ b/crates/dragonfly-server/src/provisioning.rs
@@ -622,6 +622,43 @@ impl ProvisioningService {
         Ok((action, workflow_id, machine))
     }
 
+    /// Recompute the current intent for an already-registered machine, for the
+    /// WebSocket push path. Returns `None` when the machine no longer exists —
+    /// the signal for the server to close the agent's socket.
+    ///
+    /// Reuses `decide_and_prepare_action` with `existing_os = None` and
+    /// `is_new = false`, which is correct because a machine only persists on a
+    /// `Wait` socket when it has no existing OS (an OS would have produced
+    /// `LocalBoot` and closed the socket on the initial checkin).
+    ///
+    /// NON-GOAL: this only drives `Wait → Execute` transitions. If the helper
+    /// computes `LocalBoot`/`Reboot`, the WebSocket handler treats it as
+    /// no-change — the push channel cannot re-probe the disk, and the agent
+    /// already acted on its initial response. Callers must not push those as new
+    /// instructions.
+    pub async fn current_intent(
+        &self,
+        machine_id: Uuid,
+    ) -> Result<Option<CheckInResponse>, ProvisioningError> {
+        let machine = match self.store.get_machine(machine_id).await {
+            Ok(Some(m)) => m,
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(ProvisioningError::Store(e)),
+        };
+
+        let (action, workflow_id, machine) = self
+            .decide_and_prepare_action(machine, None, false)
+            .await?;
+
+        Ok(Some(CheckInResponse {
+            machine_id: machine.id.to_string(),
+            memorable_name: machine.config.memorable_name,
+            is_new: false,
+            action,
+            workflow_id,
+        }))
+    }
+
     /// Create machine from check-in info
     fn create_machine_from_checkin(
         &self,
@@ -1436,6 +1473,77 @@ mod tests {
             response.workflow_id.is_some(),
             "Should have workflow_id for reimaging"
         );
+    }
+
+    #[tokio::test]
+    async fn test_current_intent_returns_none_for_missing_machine() {
+        let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
+        let service = ProvisioningService::new(store, test_ipxe_config(), DeploymentMode::Simple);
+
+        // A machine that does not exist signals the socket to close.
+        let result = service.current_intent(Uuid::now_v7()).await.unwrap();
+        assert!(result.is_none(), "Missing machine should signal socket close");
+    }
+
+    #[tokio::test]
+    async fn test_current_intent_wait_then_execute_on_os_choice() {
+        let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
+        let service =
+            ProvisioningService::new(store.clone(), test_ipxe_config(), DeploymentMode::Simple);
+
+        // Register a no-OS machine: no os_choice, no default_os -> Wait.
+        let response = service.handle_checkin(&test_checkin()).await.unwrap();
+        assert_eq!(response.action, AgentAction::Wait);
+        let machine_id: Uuid = response.machine_id.parse().unwrap();
+
+        // Push path with nothing changed -> still Wait.
+        let intent = service.current_intent(machine_id).await.unwrap().unwrap();
+        assert_eq!(intent.action, AgentAction::Wait);
+        assert!(intent.workflow_id.is_none());
+
+        // Admin assigns an OS (mirrors assign_os setting os_choice).
+        let mut machine = store.get_machine(machine_id).await.unwrap().unwrap();
+        machine.config.os_choice = Some("debian-12".to_string());
+        store.put_machine(&machine).await.unwrap();
+
+        // Push path must now create the workflow and return Execute.
+        let intent = service.current_intent(machine_id).await.unwrap().unwrap();
+        assert_eq!(intent.action, AgentAction::Execute);
+        assert!(
+            intent.workflow_id.is_some(),
+            "Push path must create the workflow"
+        );
+
+        // The workflow must actually be in the store.
+        let wfs = store.get_workflows_for_machine(machine_id).await.unwrap();
+        assert!(wfs.iter().any(|w| w
+            .status
+            .as_ref()
+            .map(|s| s.state == WorkflowState::StatePending)
+            .unwrap_or(false)));
+    }
+
+    #[tokio::test]
+    async fn test_current_intent_returns_execute_after_precreated_workflow() {
+        let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
+        let service =
+            ProvisioningService::new(store.clone(), test_ipxe_config(), DeploymentMode::Simple);
+
+        let response = service.handle_checkin(&test_checkin()).await.unwrap();
+        let machine_id: Uuid = response.machine_id.parse().unwrap();
+        let machine = store.get_machine(machine_id).await.unwrap().unwrap();
+
+        // reimage_machine pre-creates a Pending workflow before the agent notices.
+        let wf = service
+            .create_imaging_workflow(&machine, "debian-12")
+            .await
+            .unwrap();
+        let precreated_id = wf.metadata.name.clone();
+
+        // Push path finds the existing active workflow and returns Execute with its id.
+        let intent = service.current_intent(machine_id).await.unwrap().unwrap();
+        assert_eq!(intent.action, AgentAction::Execute);
+        assert_eq!(intent.workflow_id.as_deref(), Some(precreated_id.as_str()));
     }
 
     #[tokio::test]

--- a/crates/dragonfly-server/src/provisioning.rs
+++ b/crates/dragonfly-server/src/provisioning.rs
@@ -428,6 +428,36 @@ impl ProvisioningService {
             }
         }
 
+        let (action, workflow_id, machine) = self
+            .decide_and_prepare_action(machine, info.existing_os.as_ref(), is_new)
+            .await?;
+
+        Ok(CheckInResponse {
+            machine_id: machine.id.to_string(),
+            memorable_name: machine.config.memorable_name,
+            is_new,
+            action,
+            workflow_id,
+        })
+    }
+
+    /// Decide the agent's next action for an already-resolved machine and perform
+    /// the side effects needed to act on it (state transitions, workflow creation).
+    ///
+    /// Extracted from `handle_checkin` so the WebSocket push path (`current_intent`)
+    /// reuses the *exact same* decision logic. Two parameters are load-bearing:
+    /// - `is_new`: gates the global `default_os` auto-assign branch. The HTTP checkin
+    ///   path passes the real value; the push path passes `false` (the machine is
+    ///   already registered).
+    /// - `existing_os`: the freshly-probed OS. The push path passes `None`, which is
+    ///   correct because a machine only reaches `Wait` when no existing OS was
+    ///   detected — see the final `Wait` arm below.
+    async fn decide_and_prepare_action(
+        &self,
+        machine: Machine,
+        existing_os: Option<&DetectedOs>,
+        is_new: bool,
+    ) -> Result<(AgentAction, Option<String>, Machine), ProvisioningError> {
         // Check for workflows
         let workflows = self.get_workflows_for_machine(&machine).await?;
         let active_workflow = workflows.into_iter().find(|wf| {
@@ -461,7 +491,7 @@ impl ProvisioningService {
                     machine.id,
                     wf.metadata.name,
                     state_desc,
-                    if info.existing_os.is_some() {
+                    if existing_os.is_some() {
                         " (will replace existing OS)"
                     } else {
                         ""
@@ -491,7 +521,7 @@ impl ProvisioningService {
                 // Rules:
                 // - No existing OS → safe to image (nothing to lose)
                 // - Has existing OS → require molly guard (os_choice + reimage_requested)
-                let os_to_install = if info.existing_os.is_none() {
+                let os_to_install = if existing_os.is_none() {
                     // No existing OS - safe to image without molly guard
                     if machine.config.os_choice.is_some() {
                         info!(
@@ -520,7 +550,7 @@ impl ProvisioningService {
                     info!(
                         "Machine {} has existing OS '{}' but reimage requested, will install {}",
                         machine.id,
-                        info.existing_os.as_ref().unwrap().name,
+                        existing_os.unwrap().name,
                         machine.config.os_choice.as_ref().unwrap()
                     );
                     machine.config.os_choice.clone()
@@ -555,7 +585,7 @@ impl ProvisioningService {
                         AgentAction::Execute,
                         machine,
                     )
-                } else if let Some(ref existing_os) = info.existing_os {
+                } else if let Some(existing_os) = existing_os {
                     // Existing OS detected and no workflow to run - boot it
                     let mut machine = machine;
 
@@ -589,13 +619,7 @@ impl ProvisioningService {
             }
         };
 
-        Ok(CheckInResponse {
-            machine_id: machine.id.to_string(),
-            memorable_name: machine.config.memorable_name,
-            is_new,
-            action,
-            workflow_id,
-        })
+        Ok((action, workflow_id, machine))
     }
 
     /// Create machine from check-in info

--- a/crates/dragonfly-server/src/test_helpers.rs
+++ b/crates/dragonfly-server/src/test_helpers.rs
@@ -6,8 +6,11 @@ use crate::auth::Settings;
 use crate::event_manager::EventManager;
 use crate::ha;
 use crate::image_cache::ImageCache;
+use crate::mode::DeploymentMode;
+use crate::provisioning::ProvisioningService;
 use crate::store::v1::MemoryStore;
 use crate::{AppState, TemplateEnv};
+use dragonfly_ipxe::IpxeConfig;
 use minijinja::Environment;
 use std::collections::HashMap;
 use std::sync::{Arc, atomic::AtomicBool};
@@ -74,6 +77,22 @@ pub async fn create_test_app_state() -> AppState {
 pub async fn create_test_api_router() -> axum::Router {
     let app_state = create_test_app_state().await;
     crate::api::api_router().with_state(app_state)
+}
+
+/// Create a test AppState with the native provisioning service enabled.
+///
+/// `create_test_app_state` leaves `provisioning: None`, which makes
+/// `/api/agent/checkin` and `/api/agent/ws` return 503. Anything exercising the
+/// agent checkin/push path needs this variant.
+pub async fn create_test_app_state_with_provisioning() -> AppState {
+    let mut state = create_test_app_state().await;
+    let provisioning = Arc::new(ProvisioningService::new(
+        state.store.clone(),
+        IpxeConfig::new("http://localhost:3000"),
+        DeploymentMode::Simple,
+    ));
+    state.provisioning = Some(provisioning);
+    state
 }
 
 #[cfg(test)]

--- a/crates/dragonfly-spark/src/cmdline.rs
+++ b/crates/dragonfly-spark/src/cmdline.rs
@@ -17,6 +17,8 @@ pub struct BootParams {
     pub server_port: u16,
     /// Whether server was specified
     pub has_server: bool,
+    /// Seconds between idle-menu rechecks (prompt reimage pickup while parked)
+    pub idle_check_secs: u16,
 }
 
 impl Default for BootParams {
@@ -25,6 +27,7 @@ impl Default for BootParams {
             server_ip: [0, 0, 0, 0],
             server_port: 3000, // Default port
             has_server: false,
+            idle_check_secs: 5,
         }
     }
 }
@@ -34,6 +37,7 @@ static mut BOOT_PARAMS: BootParams = BootParams {
     server_ip: [0, 0, 0, 0],
     server_port: 3000,
     has_server: false,
+    idle_check_secs: 5,
 };
 
 /// Parse multiboot2 info to extract command line
@@ -176,6 +180,23 @@ fn parse_params(cmdline: &str) {
                     serial::print_dec(port as u32);
                 }
             }
+            serial::println("");
+        }
+    }
+
+    // Parse idle_check_secs (Spark's idle-menu recheck interval)
+    if let Some(start) = cmdline.find("idle_check_secs=") {
+        let value_start = start + "idle_check_secs=".len();
+        let value_end = cmdline[value_start..]
+            .find(|c: char| c.is_whitespace())
+            .map(|i| value_start + i)
+            .unwrap_or(cmdline.len());
+        if let Some(secs) = parse_u16(&cmdline[value_start..value_end]) {
+            unsafe {
+                BOOT_PARAMS.idle_check_secs = secs;
+            }
+            serial::print("Parsed idle_check_secs: ");
+            serial::print_dec(secs as u32);
             serial::println("");
         }
     }

--- a/crates/dragonfly-spark/src/ui.rs
+++ b/crates/dragonfly-spark/src/ui.rs
@@ -7,6 +7,11 @@ use crate::disk::OsInfo;
 use crate::font;
 use crate::framebuffer::{self, colors};
 use crate::bios;
+use crate::chainload;
+use crate::cmdline;
+use crate::http;
+use crate::net;
+use crate::serial;
 use smoltcp::wire::Ipv4Address;
 
 /// Menu choices - all possible actions from the menu system
@@ -185,6 +190,11 @@ fn draw_main_menu(os: Option<&OsInfo>, width: u32, height: u32, _has_net: bool, 
         }
     }
 
+    // Idle recheck cadence: how often (while parked at this menu) we re-check-in
+    // with the server so a reimage/reboot is noticed without a keypress.
+    let mut last_check_millis = net::now().total_millis();
+    let idle_check_ms = i64::from(cmdline::params().idle_check_secs) * 1000;
+
     loop {
         // Check for keypress
         if let Some(scancode) = bios::read_scancode() {
@@ -210,6 +220,38 @@ fn draw_main_menu(os: Option<&OsInfo>, width: u32, height: u32, _has_net: bool, 
                     stack.freeze_dhcp();
                     draw_ip_footer(width, height, ip);
                     ip_displayed = true;
+                }
+            }
+        }
+
+        // Bounded idle recheck: a machine parked at this menu notices a
+        // server-assigned reimage/reboot without a manual keypress. This is the
+        // only way to wake on no_std bare metal (interrupts are disabled), and it
+        // is scoped to this idle state only.
+        if ip_displayed {
+            let now = net::now().total_millis();
+            if now.saturating_sub(last_check_millis) >= idle_check_ms {
+                last_check_millis = now;
+                if let Some(stack) = net_stack.as_mut() {
+                    let (server_ip, server_port) = crate::resolve_server(stack);
+                    let mac = stack.device.mac_address();
+                    if let Some(response) =
+                        http::checkin(stack, server_ip, server_port, &mac, os)
+                    {
+                        match response.action {
+                            http::AgentAction::Execute => {
+                                serial::println(
+                                    "Idle recheck: server assigned imaging, booting Mage",
+                                );
+                                chainload::boot_imaging();
+                            }
+                            http::AgentAction::Reboot => {
+                                serial::println("Idle recheck: server requested reboot");
+                                bios::reboot();
+                            }
+                            _ => {} // Wait/LocalBoot: stay in the menu
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #18.

## What & why
When a machine is told to reimage, it previously sat idle until the Mage agent's next **30s** check-in poll. This adds a WebSocket push channel so the agent receives the intent the moment it's set, plus a bounded idle recheck for Spark's no_std menu. It honors the project's "no polling" rule by *eliminating* the Mage poll (steady state = one open socket) rather than excepting it.

## Changes

**Server (`dragonfly-server`)**
- `GET /api/agent/ws` — WebSocket push endpoint. The agent sends a `HardwareCheckIn`; the server replies with a `CheckInResponse` and keeps the socket open, pushing a fresh response whenever the machine's intent changes. Driven by a single `select!` loop over inbound messages / `EventManager` notifications / pings.
- `ProvisioningService::current_intent` — recomputes intent on each `machine_updated:{id}` (pull-on-notification), reusing `decide_and_prepare_action` (refactored out of `handle_checkin`, byte-identical).
- `assign_os` now emits `machine_updated` — it was the only intent-mutating handler missing the event, so OS-assign now actually triggers a push.
- `DRAGONFLY_AGENT_WS=1` opt-in: iPXE emits `dragonfly.url` as `ws://` (scheme-swapped from the boot URL), so every Mage netboot uses the channel automatically.

**Mage agent (`dragonfly-agent`)**
- New `ws` module: persistent `/api/agent/ws` connection with capped exponential backoff + ±3ms jitter on reconnect; replaces the 30s `sleep`+poll loop when the server URL is `ws://`/`wss://` (`http://` keeps the poll unchanged).
- Shared `build_checkin_payload` so the HTTP and WS paths send identical payloads.

**Spark (`dragonfly-spark`)**
- Bounded idle recheck in the "No OS" menu (default 5s, `idle_check_secs=` multiboot param) — the only wake mechanism on no_std bare metal; reboots into Mage on `execute`.

## Testing
- 164 server + 16 agent + 19 iPXE tests green; workspace compiles clean; Spark compiles on the `x86_64-spark` bare-metal target.
- New end-to-end integration test: real server router on a socket + a real `tokio-tungstenite` client → asserts `execute` is pushed on intent change.
- **Verified on real metal**: deployed to the production box (10.7.1.100); a real client connected, got `wait`, and received a pushed `execute` near-instantly on reimage trigger (old binary → 404 on `/api/agent/ws`; new binary → live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)