### PR TITLE
Add /api/events/ws WebSocket event stream (deprecate SSE)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
  "sha1 0.10.6",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -1660,7 +1660,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1981,6 +1981,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.27.0",
  "tokio-util",
  "tower 0.4.13",
  "tower-cookies",
@@ -2157,7 +2158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3178,7 +3179,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4526,7 +4527,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5462,7 +5463,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5499,9 +5500,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6260,7 +6261,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7373,7 +7374,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7706,6 +7707,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -7713,7 +7726,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -8010,6 +8023,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"
@@ -8544,7 +8574,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/dragonfly-server/Cargo.toml
+++ b/crates/dragonfly-server/Cargo.toml
@@ -155,3 +155,5 @@ minijinja-embed = "2.3.0"
 [dev-dependencies]
 tempfile = "3.8"
 serial_test = "3.0"
+# WebSocket client for the events-stream integration test.
+tokio-tungstenite = { version = "0.27" }

--- a/crates/dragonfly-server/src/api.rs
+++ b/crates/dragonfly-server/src/api.rs
@@ -239,6 +239,7 @@ pub fn api_router() -> Router<crate::AppState> {
         )
         .route("/installation/progress", put(update_installation_progress))
         .route("/events", get(machine_events))
+        .route("/events/ws", get(crate::events_ws::events_ws_handler))
         .route("/heartbeat", get(heartbeat))
         // --- Proxmox Routes ---
         .route("/proxmox/status", get(proxmox_status))
@@ -2262,6 +2263,9 @@ async fn get_machine_os(Path(id): Path<Uuid>) -> Response {
     "#, id)).into_response()
 }
 
+/// DEPRECATED: SSE event stream. Replaced by the WebSocket `GET /api/events/ws`
+/// (`events_ws::events_ws_handler`). Retained only until the UI's `EventSource`
+/// consumers migrate off SSE — do not add new consumers. See issue #20.
 // Rename from sse_events to machine_events to match the function name used in the working implementation
 async fn machine_events(
     State(state): State<AppState>,

--- a/crates/dragonfly-server/src/events_ws.rs
+++ b/crates/dragonfly-server/src/events_ws.rs
@@ -1,0 +1,183 @@
+//! WebSocket event stream for external consumers (web UI, orchestrators like
+//! Jetpack) — the replacement for the deprecated SSE `GET /api/events`.
+//!
+//! Subscribes to the server's `EventManager` broadcast bus and forwards every
+//! event as a JSON message, so consumers can track the fleet fully event-driven
+//! with no polling. See issue #20.
+
+use std::time::Duration;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::Response;
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use tokio::sync::broadcast;
+use tokio::time::interval;
+use tracing::warn;
+
+use crate::AppState;
+
+/// WebSocket ping interval for liveness detection.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// HTTP handler that upgrades an event-stream connection to a WebSocket.
+///
+/// The WebSocket successor to the deprecated SSE `GET /api/events`. Open to any
+/// caller (UI and external orchestrators); the stream is fan-out-only — clients
+/// receive events, they don't need to send. On connect the server emits a single
+/// `{"type":"stream_ready"}` message so clients can confirm the stream is live
+/// (and gate on it) before acting.
+pub async fn events_ws_handler(
+    State(state): State<AppState>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    ws.on_upgrade(move |socket| run_events_ws(socket, state))
+}
+
+/// Drive a single event-stream WebSocket for its lifetime.
+async fn run_events_ws(socket: WebSocket, state: AppState) {
+    let (mut sender, mut receiver) = socket.split();
+    let mut event_rx = state.event_manager.subscribe();
+
+    // Announce the stream is live (also lets clients/tests gate on subscription).
+    let ready = serde_json::json!({ "type": "stream_ready" }).to_string();
+    if sender.send(Message::Text(ready.into())).await.is_err() {
+        return;
+    }
+
+    let mut ping = interval(PING_INTERVAL);
+    ping.tick().await; // discard the immediate first tick
+
+    loop {
+        tokio::select! {
+            evt = event_rx.recv() => match evt {
+                Ok(event_string) => {
+                    if let Some(envelope) = event_envelope(&event_string) {
+                        let json = serde_json::to_string(&envelope).unwrap_or_else(|_| "{}".to_string());
+                        if sender.send(Message::Text(json.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(lag = n, "events websocket lagged; some events dropped");
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            },
+            msg = receiver.next() => match msg {
+                Some(Ok(Message::Close(_))) | None => break,
+                Some(Ok(Message::Ping(p))) => { let _ = sender.send(Message::Pong(p)).await; }
+                Some(Ok(_)) => {} // ignore inbound text/binary/pong
+                Some(Err(_)) => break,
+            },
+            _ = ping.tick() => {
+                if sender.send(Message::Ping(Bytes::new())).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+    let _ = sender.send(Message::Close(None)).await;
+}
+
+/// Build the uniform JSON envelope for an event: `{"type", "payload"}`.
+///
+/// `payload` is the id string for ordinary events
+/// (`machine_updated:<uuid>` -> `payload` = `"<uuid>"`) and the parsed JSON
+/// object for raw-payload events (`workflow_progress:{...}`). Returns `None` for
+/// raw-payload events that arrive without a payload (mirrors the SSE handler's
+/// skip-on-missing-payload behaviour).
+pub(crate) fn event_envelope(event_string: &str) -> Option<serde_json::Value> {
+    let (kind, payload) = event_string.split_once(':').unwrap_or((event_string, ""));
+    if matches!(kind, "ip_download_progress" | "workflow_progress" | "cluster") {
+        if payload.is_empty() {
+            return None;
+        }
+        let parsed: serde_json::Value =
+            serde_json::from_str(payload).unwrap_or_else(|_| serde_json::json!(payload));
+        Some(serde_json::json!({ "type": kind, "payload": parsed }))
+    } else {
+        Some(serde_json::json!({ "type": kind, "payload": payload }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_for_ordinary_event() {
+        let v = event_envelope("machine_updated:abc-123").unwrap();
+        assert_eq!(v["type"], "machine_updated");
+        assert_eq!(v["payload"], "abc-123");
+    }
+
+    #[test]
+    fn envelope_for_event_without_id() {
+        let v = event_envelope("templates_ready").unwrap();
+        assert_eq!(v["type"], "templates_ready");
+        assert_eq!(v["payload"], "");
+    }
+
+    #[test]
+    fn envelope_for_raw_payload_event() {
+        let v = event_envelope("workflow_progress:{\"step\":3,\"done\":false}").unwrap();
+        assert_eq!(v["type"], "workflow_progress");
+        assert_eq!(v["payload"]["step"], 3);
+        assert_eq!(v["payload"]["done"], false);
+    }
+
+    #[test]
+    fn envelope_drops_raw_payload_event_without_payload() {
+        assert!(event_envelope("workflow_progress").is_none());
+    }
+
+    /// End-to-end: a real client receives events forwarded from the EventManager.
+    #[tokio::test]
+    async fn events_ws_forwards_eventmanager_events() {
+        use crate::api::api_router;
+        use crate::test_helpers::create_test_app_state;
+        use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+        let state = create_test_app_state().await;
+        let app = axum::Router::new()
+            .nest("/api", api_router())
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app.into_make_service()).await;
+        });
+
+        let url = format!("ws://{addr}/api/events/ws");
+        let (mut ws, _) = connect_async(url.as_str()).await.unwrap();
+
+        // The server announces readiness after subscribing, so by the time we've
+        // read it, the handler is subscribed — no race when we then send.
+        let ready = ws.next().await.unwrap().unwrap();
+        let ready_str = match ready {
+            Message::Text(t) => t.to_string(),
+            other => panic!("expected stream_ready text, got {other:?}"),
+        };
+        let ready_v: serde_json::Value = serde_json::from_str(&ready_str).unwrap();
+        assert_eq!(ready_v["type"], "stream_ready");
+
+        // Push an event on the bus; the WS must forward it.
+        let _ = state
+            .event_manager
+            .send("machine_updated:deadbeef".to_string());
+        let msg = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("timed out waiting for forwarded event")
+            .unwrap()
+            .unwrap();
+        let text = match msg {
+            Message::Text(t) => t.to_string(),
+            other => panic!("expected text, got {other:?}"),
+        };
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["type"], "machine_updated");
+        assert_eq!(v["payload"], "deadbeef");
+    }
+}

--- a/crates/dragonfly-server/src/lib.rs
+++ b/crates/dragonfly-server/src/lib.rs
@@ -44,6 +44,7 @@ mod auth;
 pub mod cluster;
 pub mod dns_sync;
 pub mod event_manager;
+pub mod events_ws;
 mod filters; // Uncomment unused module
 pub mod ha;
 pub mod handlers;


### PR DESCRIPTION
Server foundation for #20. Unblocks event-driven orchestrators (Jetpack) on `/api/events/ws` — the WebSocket successor to the deprecated SSE stream.

## What
- **`GET /api/events/ws`** (`crates/dragonfly-server/src/events_ws.rs`) — upgrades to a WebSocket, subscribes to the `EventManager` broadcast bus, and forwards every event as a uniform `{"type","payload"}` JSON message. Sends a `{"type":"stream_ready"}` hello on connect so consumers can confirm the stream is live before acting, with 30s ping keepalive. Single `select!` loop (mirrors the agent WS handler shape from #19), handles broadcast `Lagged` by continuing.
- **SSE `GET /api/events` marked deprecated** — retained verbatim until the UI's `EventSource` consumers migrate. No behavior change.

## Why
SSE is deprecated in favor of WebSocket — one bidirectional transport for all real-time consumers (agents already on WS via #19; this brings the UI + orchestrators onto WS too), no per-event HTTP framing, better through proxies. Lets consumers go fully event-driven (e.g. Jetpack provisioning each machine the instant it reports `Installed`, zero polling).

## Non-breaking
The UI still uses SSE and is untouched here, so nothing breaks. This PR is independently mergeable.

## Tests
4 `event_envelope` unit tests (ordinary, no-id, raw-payload, missing-payload) + 1 end-to-end integration (real router on a socket + real `tokio-tungstenite` client receives a forwarded event after `event_manager.send`). 162 server tests green.

## Out of scope (tracked in #20)
Migrating the 7 UI `EventSource` sites + the HTMX `hx-sse`, removing SSE once migrated, and README/docs — phased as a follow-up so this server endpoint can ship and unblock consumers now.

Refs: #20, #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)