### PR TITLE
Stop rebooting VMs on reimage

### DIFF
--- a/crates/dragonfly-server/src/api.rs
+++ b/crates/dragonfly-server/src/api.rs
@@ -6482,39 +6482,13 @@ async fn reimage_machine(
         workflow_id, id, os_choice
     );
 
-    // Convert to common Machine for Proxmox reboot
-    let machine: Machine = crate::store::conversions::machine_to_common(&v1_machine);
-
-    // Emit machine updated event
+    // Emit machine updated event. This is the imaging trigger: an agent already
+    // in Mage receives the reimage over the push channel, and Spark (via its
+    // idle re-check) picks it up on the next check-in. We deliberately do NOT
+    // reboot here — `qm reboot` on a guest without qemu-guest-agent is an ACPI
+    // reboot the guest ignores, so PVE blocks that VMID's API until the reboot
+    // times out; a forced net-boot only matters for bare metal (IPMI), not VMs.
     let _ = state.event_manager.send(format!("machine_updated:{}", id));
-
-    // If this is a Proxmox VM, reboot it into PXE boot mode
-    if machine.proxmox_vmid.is_some() && machine.proxmox_node.is_some() {
-        info!("Rebooting Proxmox VM {} for reimage", id);
-        // Create a request to reboot into PXE
-        let power_action = crate::handlers::machines::BmcPowerActionRequest {
-            action: "reboot-pxe".to_string(),
-        };
-
-        // Call the power action handler
-        match crate::handlers::machines::bmc_power_action_handler(
-            State(state.clone()),
-            Path(id),
-            Json(power_action),
-        )
-        .await
-        {
-            Ok(_) => {
-                info!("Successfully initiated PXE reboot for Proxmox VM {}", id);
-            }
-            Err(e) => {
-                // Log the error but continue - machine state is updated, just reboot failed
-                error!("Failed to reboot Proxmox VM {}: {:?}", id, e);
-            }
-        }
-    } else {
-        info!("Machine {} is not a Proxmox VM, skipping reboot", id);
-    }
 
     // Return success response
     let response_html = format!(


### PR DESCRIPTION
Removes the automatic `reboot-pxe` (`qm reboot`) call from `reimage_machine`.

## Why
- **Unsafe:** `qm reboot` is a *guest* ACPI reboot. Without `qemu-guest-agent` the guest ignores it, so PVE blocks that **VMID's API until the reboot times out**, and any action queued behind it fails. A lock-out, not a trigger.
- **Wrong model for fresh imaging:** a no-OS VM sits in Spark's menu; imaging is driven by `assign_os` + the agent's check-in (`handle_checkin` creates the workflow when `os_choice` is set), not a reboot. The reboot was only ever meaningful for re-imaging a machine already running its installed OS.

## What changed
The imaging trigger is now the `machine_updated` event this handler already emits: an agent in Mage receives the reimage over the push channel (#19), and Spark picks it up via its idle re-check (#19, now deployed). `reboot-pxe` remains available as a manual bare-metal (IPMI) power action — just no longer auto-fired on reimage.

## Follow-up
Re-imaging a running-OS VM will need a *safe* boot-into-Mage mechanism (reset / stop+start, or gated on guest-agent presence) — tracked separately. The unsafe `qm reboot` is removed now precisely because it causes API lock-outs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)