### PR TITLE
Force StaticIpv4 when a static IPv4 address is configured

### DIFF
--- a/crates/dragonfly-agent/examples/events_probe.rs
+++ b/crates/dragonfly-agent/examples/events_probe.rs
@@ -21,7 +21,9 @@ async fn main() -> anyhow::Result<()> {
     let base = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "ws://localhost:3000".to_string());
-    let http = base.replacen("ws://", "http://", 1).replacen("wss://", "https://", 1);
+    let http = base
+        .replacen("ws://", "http://", 1)
+        .replacen("wss://", "https://", 1);
 
     let url = format!("{base}/api/events/ws");
     println!("connecting to {url}");

--- a/crates/dragonfly-agent/examples/ws_probe.rs
+++ b/crates/dragonfly-agent/examples/ws_probe.rs
@@ -32,7 +32,9 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| "ws://localhost:3000".to_string());
     let mac = env_or("WS_PROBE_MAC", "00:11:22:33:44:aa");
     let template = env_or("WS_PROBE_TEMPLATE", "debian-12");
-    let http_base = base.replacen("ws://", "http://", 1).replacen("wss://", "https://", 1);
+    let http_base = base
+        .replacen("ws://", "http://", 1)
+        .replacen("wss://", "https://", 1);
 
     let url = format!("{base}/api/agent/ws");
     println!("connecting to {url} (mac={mac}, template={template})");

--- a/crates/dragonfly-common/src/models.rs
+++ b/crates/dragonfly-common/src/models.rs
@@ -199,8 +199,14 @@ pub struct RegisterRequest {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AdminCreateMachineRequest {
+    /// Primary MAC — required; Dragonfly keys the machine on it.
     pub mac_address: String,
-    pub ip_address: String,
+    /// Static IPv4 address. When present the machine is created in `StaticIpv4`
+    /// mode (cloud-init bakes it; an IP reservation is made when `network_id`
+    /// is also set). When absent the machine is left in the default `Dhcp`
+    /// mode — equivalent to the open registration path.
+    #[serde(default)]
+    pub ip_address: Option<String>,
     #[serde(default)]
     pub hostname: Option<String>,
     #[serde(default)]

--- a/crates/dragonfly-ipxe/src/script.rs
+++ b/crates/dragonfly-ipxe/src/script.rs
@@ -525,7 +525,10 @@ boot
         // Dragonfly parameters
         params.push(format!(
             "dragonfly.url={}",
-            self.config.agent_url.as_deref().unwrap_or(&self.config.base_url)
+            self.config
+                .agent_url
+                .as_deref()
+                .unwrap_or(&self.config.base_url)
         ));
         params.push(format!("dragonfly.mode={}", mode));
         params.push("dragonfly.mac=${mac}".to_string());
@@ -572,7 +575,10 @@ boot
         // Dragonfly parameters
         params.push(format!(
             "dragonfly.url={}",
-            self.config.agent_url.as_deref().unwrap_or(&self.config.base_url)
+            self.config
+                .agent_url
+                .as_deref()
+                .unwrap_or(&self.config.base_url)
         ));
         params.push(format!("dragonfly.mode={}", mode));
         params.push("dragonfly.mac=${mac}".to_string());

--- a/crates/dragonfly-server/src/agent_ws.rs
+++ b/crates/dragonfly-server/src/agent_ws.rs
@@ -11,11 +11,11 @@
 //! `machine_updated:{id}` notification (pull-on-notification, not event
 //! sourcing), so steady state is one open socket with no periodic polling.
 
-use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::Json;
 use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use bytes::Bytes;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
@@ -25,8 +25,8 @@ use tokio::time::{interval, timeout};
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::provisioning::{AgentAction, CheckInResponse, HardwareCheckIn};
 use crate::AppState;
+use crate::provisioning::{AgentAction, CheckInResponse, HardwareCheckIn};
 
 /// Time to wait for the agent's first `HardwareCheckIn` message before giving up.
 const FIRST_MESSAGE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -39,10 +39,7 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
 /// is established MAC-bound from the first message via `handle_checkin`. A WS
 /// connection is longer-lived than a POST, but the threat model is unchanged —
 /// an attacker who can reach the server can already spoof checkins today.
-pub async fn agent_ws_handler(
-    State(state): State<AppState>,
-    ws: WebSocketUpgrade,
-) -> Response {
+pub async fn agent_ws_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
     if state.provisioning.is_none() {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -180,7 +177,9 @@ async fn run_agent_ws(socket: WebSocket, state: AppState) {
 
 /// Read and parse the first message as a `HardwareCheckIn`, with a timeout.
 async fn read_first_checkin(receiver: &mut SplitStream<WebSocket>) -> Option<HardwareCheckIn> {
-    let msg = timeout(FIRST_MESSAGE_TIMEOUT, receiver.next()).await.ok()??;
+    let msg = timeout(FIRST_MESSAGE_TIMEOUT, receiver.next())
+        .await
+        .ok()??;
     match msg {
         Ok(Message::Text(text)) => serde_json::from_str(&text).ok(),
         _ => None,
@@ -193,7 +192,10 @@ async fn send_response(
     response: &CheckInResponse,
 ) -> Result<(), ()> {
     let json = serde_json::to_string(response).map_err(|_| ())?;
-    sender.send(Message::Text(json.into())).await.map_err(|_| ())
+    sender
+        .send(Message::Text(json.into()))
+        .await
+        .map_err(|_| ())
 }
 
 /// Whether a freshly-computed intent should be pushed to the agent.
@@ -248,8 +250,14 @@ mod tests {
     fn event_concerns_machine_ignores_other_machines_and_types() {
         let id = Uuid::now_v7();
         let other = Uuid::now_v7();
-        assert!(!event_concerns_machine(&format!("machine_updated:{other}"), id));
-        assert!(!event_concerns_machine(&format!("workflow_progress:{id}"), id));
+        assert!(!event_concerns_machine(
+            &format!("machine_updated:{other}"),
+            id
+        ));
+        assert!(!event_concerns_machine(
+            &format!("workflow_progress:{id}"),
+            id
+        ));
         assert!(!event_concerns_machine("templates_ready", id));
     }
 

--- a/crates/dragonfly-server/src/api.rs
+++ b/crates/dragonfly-server/src/api.rs
@@ -119,7 +119,11 @@ fn build_machine_source(req: &AdminCreateMachineRequest) -> MachineSource {
                 req.proxmox_node.clone(),
                 req.proxmox_vmid,
             ) {
-                MachineSource::ProxmoxLxc { cluster, node, ctid }
+                MachineSource::ProxmoxLxc {
+                    cluster,
+                    node,
+                    ctid,
+                }
             } else {
                 MachineSource::Manual
             }
@@ -156,7 +160,10 @@ fn build_machine_source(req: &AdminCreateMachineRequest) -> MachineSource {
 /// create and update branches of `admin_create_machine`). Extracted from the
 /// handler so the static-vs-DHCP decision is unit-testable without standing up
 /// the router/auth stack.
-fn apply_admin_create_config(machine: &mut dragonfly_common::Machine, payload: &AdminCreateMachineRequest) {
+fn apply_admin_create_config(
+    machine: &mut dragonfly_common::Machine,
+    payload: &AdminCreateMachineRequest,
+) {
     machine.metadata.source = build_machine_source(payload);
     machine.metadata.updated_at = chrono::Utc::now();
     machine.status.current_ip = payload.ip_address.clone();
@@ -761,7 +768,10 @@ async fn admin_create_machine(
             (machine, true)
         }
         Err(e) => {
-            error!("Failed to lookup existing machine by MAC {}: {}", normalized_mac, e);
+            error!(
+                "Failed to lookup existing machine by MAC {}: {}",
+                normalized_mac, e
+            );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({
@@ -811,7 +821,10 @@ async fn admin_create_machine(
                 .into_response()
         }
         Err(e) => {
-            error!("Failed to save precreated machine {}: {}", normalized_mac, e);
+            error!(
+                "Failed to save precreated machine {}: {}",
+                normalized_mac, e
+            );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({
@@ -10439,7 +10452,10 @@ mod admin_create_tests {
     #[test]
     fn static_ip_configures_static_ipv4_mode() {
         let mut machine = fresh_machine();
-        apply_admin_create_config(&mut machine, &request("bc:24:11:22:33:44", Some("10.7.1.241")));
+        apply_admin_create_config(
+            &mut machine,
+            &request("bc:24:11:22:33:44", Some("10.7.1.241")),
+        );
 
         assert_eq!(machine.config.network_mode, NetworkMode::StaticIpv4);
         let cfg = machine
@@ -10477,7 +10493,10 @@ mod admin_create_tests {
     #[test]
     fn re_precreate_without_ip_converges_back_to_dhcp() {
         let mut machine = fresh_machine();
-        apply_admin_create_config(&mut machine, &request("bc:24:11:22:33:44", Some("10.7.1.241")));
+        apply_admin_create_config(
+            &mut machine,
+            &request("bc:24:11:22:33:44", Some("10.7.1.241")),
+        );
         assert_eq!(machine.config.network_mode, NetworkMode::StaticIpv4);
 
         // A second precreate that drops the IP must reset to DHCP.

--- a/crates/dragonfly-server/src/api.rs
+++ b/crates/dragonfly-server/src/api.rs
@@ -152,12 +152,53 @@ fn build_machine_source(req: &AdminCreateMachineRequest) -> MachineSource {
     }
 }
 
+/// Apply an `AdminCreateMachineRequest` to a machine record (used for both the
+/// create and update branches of `admin_create_machine`). Extracted from the
+/// handler so the static-vs-DHCP decision is unit-testable without standing up
+/// the router/auth stack.
+fn apply_admin_create_config(machine: &mut dragonfly_common::Machine, payload: &AdminCreateMachineRequest) {
+    machine.metadata.source = build_machine_source(payload);
+    machine.metadata.updated_at = chrono::Utc::now();
+    machine.status.current_ip = payload.ip_address.clone();
+    if machine.status.last_seen.is_none() {
+        machine.status.state = MachineState::Offline;
+    }
+    machine.config.hostname = payload.hostname.clone();
+    match &payload.ip_address {
+        Some(ip) => {
+            machine.config.network_mode = NetworkMode::StaticIpv4;
+            machine.config.static_ipv4 = Some(StaticIpConfig {
+                address: ip.clone(),
+                prefix_len: payload.prefix_len.unwrap_or(24),
+                gateway: payload.gateway.clone(),
+            });
+        }
+        None => {
+            // No static IP declared → DHCP. Reset any prior static config so a
+            // re-precreate that drops the IP converges the machine back to DHCP.
+            machine.config.network_mode = NetworkMode::Dhcp;
+            machine.config.static_ipv4 = None;
+        }
+    }
+    machine.config.nameservers = payload.nameservers.clone();
+    machine.config.domain = payload.domain.clone();
+    machine.config.network_id = payload.network_id;
+    machine.config.tags = payload.tags.clone();
+    machine.config.pending_apply = false;
+    machine.config.pending_fields.clear();
+}
+
 async fn upsert_network_reservation_for_machine(
     state: &AppState,
     req: &AdminCreateMachineRequest,
     hostname: Option<String>,
 ) -> Result<(), String> {
     let Some(network_id) = req.network_id else {
+        return Ok(());
+    };
+    // A static reservation needs an IP. DHCP machines (no ip_address) have
+    // nothing to reserve — and this path is only reached when network_id is set.
+    let Some(ip) = req.ip_address.clone() else {
         return Ok(());
     };
 
@@ -174,12 +215,12 @@ async fn upsert_network_reservation_for_machine(
         .iter_mut()
         .find(|res| dragonfly_common::normalize_mac(&res.mac) == normalized_mac)
     {
-        existing.ip = req.ip_address.clone();
+        existing.ip = ip;
         existing.hostname = hostname;
     } else {
         network.reservations.push(dragonfly_common::StaticLease {
             mac: normalized_mac,
-            ip: req.ip_address.clone(),
+            ip,
             hostname,
         });
     }
@@ -732,25 +773,7 @@ async fn admin_create_machine(
         }
     };
 
-    machine.metadata.source = build_machine_source(&payload);
-    machine.metadata.updated_at = chrono::Utc::now();
-    machine.status.current_ip = Some(payload.ip_address.clone());
-    if machine.status.last_seen.is_none() {
-        machine.status.state = MachineState::Offline;
-    }
-    machine.config.hostname = payload.hostname.clone();
-    machine.config.network_mode = NetworkMode::StaticIpv4;
-    machine.config.static_ipv4 = Some(StaticIpConfig {
-        address: payload.ip_address.clone(),
-        prefix_len: payload.prefix_len.unwrap_or(24),
-        gateway: payload.gateway.clone(),
-    });
-    machine.config.nameservers = payload.nameservers.clone();
-    machine.config.domain = payload.domain.clone();
-    machine.config.network_id = payload.network_id;
-    machine.config.tags = payload.tags.clone();
-    machine.config.pending_apply = false;
-    machine.config.pending_fields.clear();
+    apply_admin_create_config(&mut machine, &payload);
 
     match upsert_network_reservation_for_machine(&state, &payload, payload.hostname.clone()).await {
         Ok(()) => {}
@@ -10382,4 +10405,84 @@ async fn dns_records_by_machine_handler(
     }
 
     Json(json!({ "records": all_records })).into_response()
+}
+
+#[cfg(test)]
+mod admin_create_tests {
+    use super::*;
+
+    fn request(mac: &str, ip: Option<&str>) -> AdminCreateMachineRequest {
+        AdminCreateMachineRequest {
+            mac_address: mac.to_string(),
+            ip_address: ip.map(str::to_string),
+            hostname: Some("k8s01".to_string()),
+            network_id: None,
+            prefix_len: Some(24),
+            gateway: Some("10.7.1.1".to_string()),
+            nameservers: vec!["10.7.1.11".to_string(), "10.7.1.12".to_string()],
+            domain: None,
+            tags: vec![],
+            proxmox_vmid: Some(101),
+            proxmox_node: Some("bee".to_string()),
+            proxmox_cluster: Some("SpaceTempAgency".to_string()),
+            proxmox_type: Some("vm".to_string()),
+        }
+    }
+
+    // NOTE: bare `Machine` in api.rs is `models::Machine` (the flat DTO). The
+    // domain model the handler + helper operate on is `dragonfly_common::Machine`
+    // (it has `::new`, `.config`, `.status`).
+    fn fresh_machine() -> dragonfly_common::Machine {
+        dragonfly_common::Machine::new(MachineIdentity::from_mac("bc:24:11:22:33:44"))
+    }
+
+    #[test]
+    fn static_ip_configures_static_ipv4_mode() {
+        let mut machine = fresh_machine();
+        apply_admin_create_config(&mut machine, &request("bc:24:11:22:33:44", Some("10.7.1.241")));
+
+        assert_eq!(machine.config.network_mode, NetworkMode::StaticIpv4);
+        let cfg = machine
+            .config
+            .static_ipv4
+            .as_ref()
+            .expect("static_ipv4 should be set");
+        assert_eq!(cfg.address, "10.7.1.241");
+        assert_eq!(cfg.prefix_len, 24);
+        assert_eq!(cfg.gateway.as_deref(), Some("10.7.1.1"));
+        assert_eq!(machine.status.current_ip.as_deref(), Some("10.7.1.241"));
+        assert_eq!(machine.config.hostname.as_deref(), Some("k8s01"));
+        assert_eq!(
+            machine.config.nameservers,
+            vec!["10.7.1.11".to_string(), "10.7.1.12".to_string()]
+        );
+    }
+
+    #[test]
+    fn no_ip_configures_dhcp_with_no_static_config() {
+        let mut machine = fresh_machine();
+        apply_admin_create_config(&mut machine, &request("bc:24:11:22:33:44", None));
+
+        assert_eq!(machine.config.network_mode, NetworkMode::Dhcp);
+        assert!(machine.config.static_ipv4.is_none());
+        assert!(machine.status.current_ip.is_none());
+        // Non-network fields are still applied in DHCP mode.
+        assert_eq!(machine.config.hostname.as_deref(), Some("k8s01"));
+        assert_eq!(
+            machine.config.nameservers,
+            vec!["10.7.1.11".to_string(), "10.7.1.12".to_string()]
+        );
+    }
+
+    #[test]
+    fn re_precreate_without_ip_converges_back_to_dhcp() {
+        let mut machine = fresh_machine();
+        apply_admin_create_config(&mut machine, &request("bc:24:11:22:33:44", Some("10.7.1.241")));
+        assert_eq!(machine.config.network_mode, NetworkMode::StaticIpv4);
+
+        // A second precreate that drops the IP must reset to DHCP.
+        apply_admin_create_config(&mut machine, &request("bc:24:11:22:33:44", None));
+        assert_eq!(machine.config.network_mode, NetworkMode::Dhcp);
+        assert!(machine.config.static_ipv4.is_none());
+    }
 }

--- a/crates/dragonfly-server/src/events_ws.rs
+++ b/crates/dragonfly-server/src/events_ws.rs
@@ -7,8 +7,8 @@
 
 use std::time::Duration;
 
-use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::Response;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
@@ -28,10 +28,7 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
 /// receive events, they don't need to send. On connect the server emits a single
 /// `{"type":"stream_ready"}` message so clients can confirm the stream is live
 /// (and gate on it) before acting.
-pub async fn events_ws_handler(
-    State(state): State<AppState>,
-    ws: WebSocketUpgrade,
-) -> Response {
+pub async fn events_ws_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
     ws.on_upgrade(move |socket| run_events_ws(socket, state))
 }
 
@@ -90,7 +87,10 @@ async fn run_events_ws(socket: WebSocket, state: AppState) {
 /// skip-on-missing-payload behaviour).
 pub(crate) fn event_envelope(event_string: &str) -> Option<serde_json::Value> {
     let (kind, payload) = event_string.split_once(':').unwrap_or((event_string, ""));
-    if matches!(kind, "ip_download_progress" | "workflow_progress" | "cluster") {
+    if matches!(
+        kind,
+        "ip_download_progress" | "workflow_progress" | "cluster"
+    ) {
         if payload.is_empty() {
             return None;
         }

--- a/crates/dragonfly-server/src/lib.rs
+++ b/crates/dragonfly-server/src/lib.rs
@@ -38,10 +38,10 @@ use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt};
 // Ensure prelude is still imported if needed elsewhere
 // use tracing_subscriber::prelude::*;
 
+pub mod agent_ws;
 mod api;
 pub mod api_token;
 mod auth;
-pub mod agent_ws;
 pub mod cluster;
 pub mod dns_sync;
 pub mod event_manager;
@@ -173,7 +173,11 @@ fn swap_to_ws(base_url: &str) -> String {
     base_url
         .strip_prefix("https://")
         .map(|r| format!("wss://{r}"))
-        .or_else(|| base_url.strip_prefix("http://").map(|r| format!("ws://{r}")))
+        .or_else(|| {
+            base_url
+                .strip_prefix("http://")
+                .map(|r| format!("ws://{r}"))
+        })
         .unwrap_or_else(|| base_url.to_string())
 }
 
@@ -1578,7 +1582,10 @@ mod agent_ws_tests {
     #[test]
     fn swap_to_ws_scheme() {
         assert_eq!(swap_to_ws("http://10.7.1.100:3000"), "ws://10.7.1.100:3000");
-        assert_eq!(swap_to_ws("https://dragonfly.example"), "wss://dragonfly.example");
+        assert_eq!(
+            swap_to_ws("https://dragonfly.example"),
+            "wss://dragonfly.example"
+        );
         // Unknown scheme passes through unchanged (agent then treats it as http).
         assert_eq!(swap_to_ws("foo://x"), "foo://x");
     }

--- a/crates/dragonfly-server/src/provisioning.rs
+++ b/crates/dragonfly-server/src/provisioning.rs
@@ -646,9 +646,8 @@ impl ProvisioningService {
             Err(e) => return Err(ProvisioningError::Store(e)),
         };
 
-        let (action, workflow_id, machine) = self
-            .decide_and_prepare_action(machine, None, false)
-            .await?;
+        let (action, workflow_id, machine) =
+            self.decide_and_prepare_action(machine, None, false).await?;
 
         Ok(Some(CheckInResponse {
             machine_id: machine.id.to_string(),
@@ -1482,7 +1481,10 @@ mod tests {
 
         // A machine that does not exist signals the socket to close.
         let result = service.current_intent(Uuid::now_v7()).await.unwrap();
-        assert!(result.is_none(), "Missing machine should signal socket close");
+        assert!(
+            result.is_none(),
+            "Missing machine should signal socket close"
+        );
     }
 
     #[tokio::test]
@@ -1516,11 +1518,12 @@ mod tests {
 
         // The workflow must actually be in the store.
         let wfs = store.get_workflows_for_machine(machine_id).await.unwrap();
-        assert!(wfs.iter().any(|w| w
-            .status
-            .as_ref()
-            .map(|s| s.state == WorkflowState::StatePending)
-            .unwrap_or(false)));
+        assert!(wfs.iter().any(|w| {
+            w.status
+                .as_ref()
+                .map(|s| s.state == WorkflowState::StatePending)
+                .unwrap_or(false)
+        }));
     }
 
     #[tokio::test]

--- a/crates/dragonfly-server/src/services.rs
+++ b/crates/dragonfly-server/src/services.rs
@@ -321,7 +321,9 @@ impl ServiceRunner {
         let socket = loop {
             match server.bind_socket().await {
                 Ok(socket) => break socket,
-                Err(err) if should_retry_dhcp_bind(&err) && attempt < Self::DHCP_BIND_RETRY_ATTEMPTS => {
+                Err(err)
+                    if should_retry_dhcp_bind(&err) && attempt < Self::DHCP_BIND_RETRY_ATTEMPTS =>
+                {
                     attempt += 1;
                     warn!(
                         attempt,

--- a/crates/dragonfly-server/src/store/conversions.rs
+++ b/crates/dragonfly-server/src/store/conversions.rs
@@ -453,6 +453,23 @@ pub fn apply_machine_update(machine: &mut Machine, req: UpdateMachineRequest) {
         // Update displayed IP to match the configured static address
         machine.status.current_ip = Some(static_ipv4.address.clone());
         machine.config.static_ipv4 = Some(static_ipv4);
+        // A configured static IPv4 address is meaningless under a DHCP mode:
+        // `generate_network_config` switches on `network_mode` first and would
+        // emit DHCP, silently dropping the address. Promote DHCP modes to
+        // StaticIpv4 so the configured address actually reaches cloud-init.
+        // Explicitly static modes (StaticIpv4/StaticIpv6/StaticDualStack) are
+        // left untouched.
+        if matches!(
+            machine.config.network_mode,
+            dragonfly_common::NetworkMode::Dhcp | dragonfly_common::NetworkMode::DhcpStaticDns
+        ) {
+            snapshot_and_mark(
+                machine,
+                "network_mode",
+                serde_json::json!(machine.config.network_mode),
+            );
+            machine.config.network_mode = dragonfly_common::NetworkMode::StaticIpv4;
+        }
     }
     if let Some(static_ipv6) = req.static_ipv6 {
         snapshot_and_mark(
@@ -829,6 +846,7 @@ pub fn source_from_register_request(req: &CommonRegisterRequest) -> Option<Machi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dragonfly_common::{NetworkMode, StaticIpConfig};
 
     fn sample_register_request() -> CommonRegisterRequest {
         CommonRegisterRequest {
@@ -845,6 +863,91 @@ mod tests {
             proxmox_cluster: None,
             proxmox_type: None,
         }
+    }
+
+    /// An `UpdateMachineRequest` with every field unset — a clean base for
+    /// partial-update tests.
+    fn empty_update_request() -> UpdateMachineRequest {
+        UpdateMachineRequest {
+            hostname: None,
+            memorable_name: None,
+            ip_address: None,
+            os_choice: None,
+            tags: None,
+            status: None,
+            network_mode: None,
+            static_ipv4: None,
+            static_ipv6: None,
+            nameservers: None,
+            domain: None,
+            network_id: None,
+            cpu_cores: None,
+            total_ram_bytes: None,
+            primary_interface: None,
+        }
+    }
+
+    fn sample_machine() -> Machine {
+        Machine::new(MachineIdentity::from_mac("00:11:22:33:44:55"))
+    }
+
+    fn static_v4(addr: &str) -> StaticIpConfig {
+        StaticIpConfig {
+            address: addr.to_string(),
+            prefix_len: 24,
+            gateway: Some("10.7.1.1".to_string()),
+        }
+    }
+
+    #[test]
+    fn static_ipv4_update_promotes_default_dhcp_to_static() {
+        // A fresh machine defaults to DHCP.
+        let mut machine = sample_machine();
+        assert_eq!(machine.config.network_mode, NetworkMode::Dhcp);
+
+        // Apply a static IPv4 address with no explicit network_mode.
+        let req = UpdateMachineRequest {
+            static_ipv4: Some(static_v4("10.7.1.55")),
+            ..empty_update_request()
+        };
+        apply_machine_update(&mut machine, req);
+
+        // The address must not be silently dropped by the DHCP mode.
+        assert_eq!(machine.config.network_mode, NetworkMode::StaticIpv4);
+        assert_eq!(
+            machine.config.static_ipv4.as_ref().unwrap().address,
+            "10.7.1.55"
+        );
+    }
+
+    #[test]
+    fn static_ipv4_update_leaves_explicit_static_modes_alone() {
+        // An explicitly static mode must not be clobbered by a v4 address.
+        let mut machine = sample_machine();
+        machine.config.network_mode = NetworkMode::StaticDualStack;
+
+        let req = UpdateMachineRequest {
+            static_ipv4: Some(static_v4("10.7.1.55")),
+            ..empty_update_request()
+        };
+        apply_machine_update(&mut machine, req);
+
+        assert_eq!(machine.config.network_mode, NetworkMode::StaticDualStack);
+    }
+
+    #[test]
+    fn static_ipv4_update_overrides_a_dhcp_mode_in_the_same_request() {
+        // A contradictory request (DHCP mode + a static address) must honour the
+        // explicit address rather than silently dropping it.
+        let mut machine = sample_machine();
+        let req = UpdateMachineRequest {
+            network_mode: Some(NetworkMode::Dhcp),
+            static_ipv4: Some(static_v4("10.7.1.55")),
+            ..empty_update_request()
+        };
+        apply_machine_update(&mut machine, req);
+
+        assert_eq!(machine.config.network_mode, NetworkMode::StaticIpv4);
     }
 
     #[test]

--- a/crates/dragonfly-server/src/store/conversions.rs
+++ b/crates/dragonfly-server/src/store/conversions.rs
@@ -958,7 +958,11 @@ mod tests {
         req.proxmox_node = Some("pve1".to_string());
         req.proxmox_cluster = Some("london".to_string());
         match source_from_register_request(&req) {
-            Some(MachineSource::Proxmox { cluster, node, vmid }) => {
+            Some(MachineSource::Proxmox {
+                cluster,
+                node,
+                vmid,
+            }) => {
                 assert_eq!(cluster, "london");
                 assert_eq!(node, "pve1");
                 assert_eq!(vmid, 106);


### PR DESCRIPTION
## What

`apply_machine_update` now promotes a DHCP `network_mode` to `StaticIpv4` whenever a `static_ipv4` address is provided.

## Why

The PATCH/update path set `static_ipv4` without touching `network_mode`. Since `generate_network_config` switches on `network_mode` first, a machine could have a static address recorded but still image as DHCP — the configured IP silently dropped. This was a latent trap separate from the main static-IP delivery work (which is inventory + Jetpack precreate).

## Behaviour

- `static_ipv4` set under `Dhcp`/`DhcpStaticDns` → promoted to `StaticIpv4`.
- Explicit static modes (`StaticIpv4`/`StaticIpv6`/`StaticDualStack`) → left untouched.
- Contradictory request (`network_mode=Dhcp` + `static_ipv4`) → honours the address, promotes to `StaticIpv4`.

## Tests

3 new tests in `store::conversions` (red→green), full module green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)