### PR TITLE
fix(os-templates): correct qemu-guest-agent runcmd

### DIFF
--- a/os-templates/debian-12.yml
+++ b/os-templates/debian-12.yml
@@ -60,9 +60,10 @@ spec:
           - |
             # Only install qemu-guest-agent if virtio serial port exists (running on QEMU/KVM)
             if [ -e /dev/virtio-ports/org.qemu.guest_agent.0 ]; then
-              apt-get install -y qemu-guest-agent
-              systemctl enable qemu-guest-agent
-              systemctl start qemu-guest-agent
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-guest-agent
+              systemctl daemon-reload
+              systemctl start qemu-guest-agent 2>/dev/null || true
             fi
       mode: "0644"
       timeout: 90

--- a/os-templates/debian-13.yml
+++ b/os-templates/debian-13.yml
@@ -60,9 +60,10 @@ spec:
           - |
             # Only install qemu-guest-agent if virtio serial port exists (running on QEMU/KVM)
             if [ -e /dev/virtio-ports/org.qemu.guest_agent.0 ]; then
-              apt-get install -y qemu-guest-agent
-              systemctl enable qemu-guest-agent
-              systemctl start qemu-guest-agent
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-guest-agent
+              systemctl daemon-reload
+              systemctl start qemu-guest-agent 2>/dev/null || true
             fi
       mode: "0644"
       timeout: 90

--- a/os-templates/rocky-10.yml
+++ b/os-templates/rocky-10.yml
@@ -61,8 +61,8 @@ spec:
             # Only install qemu-guest-agent if virtio serial port exists (running on QEMU/KVM)
             if [ -e /dev/virtio-ports/org.qemu.guest_agent.0 ]; then
               dnf install -y qemu-guest-agent
-              systemctl enable qemu-guest-agent
-              systemctl start qemu-guest-agent
+              systemctl daemon-reload
+              systemctl start qemu-guest-agent 2>/dev/null || true
             fi
       mode: "0644"
       timeout: 90

--- a/os-templates/ubuntu-2204.yml
+++ b/os-templates/ubuntu-2204.yml
@@ -60,9 +60,10 @@ spec:
           - |
             # Only install qemu-guest-agent if virtio serial port exists (running on QEMU/KVM)
             if [ -e /dev/virtio-ports/org.qemu.guest_agent.0 ]; then
-              apt-get install -y qemu-guest-agent
-              systemctl enable qemu-guest-agent
-              systemctl start qemu-guest-agent
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-guest-agent
+              systemctl daemon-reload
+              systemctl start qemu-guest-agent 2>/dev/null || true
             fi
       mode: "0644"
       timeout: 90

--- a/os-templates/ubuntu-2404.yml
+++ b/os-templates/ubuntu-2404.yml
@@ -60,9 +60,10 @@ spec:
           - |
             # Only install qemu-guest-agent if virtio serial port exists (running on QEMU/KVM)
             if [ -e /dev/virtio-ports/org.qemu.guest_agent.0 ]; then
-              apt-get install -y qemu-guest-agent
-              systemctl enable qemu-guest-agent
-              systemctl start qemu-guest-agent
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-guest-agent
+              systemctl daemon-reload
+              systemctl start qemu-guest-agent 2>/dev/null || true
             fi
       mode: "0644"
       timeout: 90


### PR DESCRIPTION
cloud-init final stage failed exit 5 on every provisioned VM: the qemu-guest-agent runcmd ran 'systemctl start' with no preceding daemon-reload (systemd hadn't scanned the unit apt just dropped), and 'systemctl enable' errored on this static (no [Install]) unit first. Last command's exit propagated -> scripts-user FAILED -> cloud-init status: error.

Fix: apt-get update + noninteractive install, daemon-reload, then start ... || true; drop the meaningless enable. debian-12/13 + ubuntu-2204/2404 (apt), rocky-10 (dnf). Rebases cleanly on main (#24 touched reimage code, not os-templates). Already deployed to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)